### PR TITLE
Supporting nested dicts in a json fashion

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -277,6 +277,13 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
         elif isinstance(node, ast.Subscript): # b[1]
             return self._eval(node.value)[self._eval(node.slice.value)]
 
+        elif isinstance(node, ast.Attribute): # a.b.c
+            try:
+                return self._eval(node.value)[node.attr]
+
+            except KeyError:
+                raise NameNotDefined(node.attr, self.expr)
+
         else:
             raise FeatureNotAvailable("Sorry, {0} is not available in this "
                                       "evaluator".format(type(node).__name__ ))

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -114,6 +114,14 @@ class NameNotDefined(InvalidExpression):
         # pylint: disable=bad-super-call
         super(InvalidExpression, self).__init__(self.message)
 
+class AttributeDoesNotExist(InvalidExpression):
+    '''attribute does not exist'''
+    def __init__(self, attr, expression):
+        self.message = "Attribute '{0}' does not exist in expression '{1}'".format(
+            attr, expression)
+        self.attr = attr
+        self.expression = expression
+ 
 class FeatureNotAvailable(InvalidExpression):
     ''' What you're trying to do is not allowed. '''
     pass
@@ -282,7 +290,7 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
                 return self._eval(node.value)[node.attr]
 
             except KeyError:
-                raise NameNotDefined(node.attr, self.expr)
+                raise AttributeDoesNotExist(node.attr, self.expr)
 
         else:
             raise FeatureNotAvailable("Sorry, {0} is not available in this "

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -9,7 +9,7 @@
 
 import unittest
 import simpleeval
-from simpleeval import SimpleEval, NameNotDefined, InvalidExpression, simple_eval
+from simpleeval import SimpleEval, NameNotDefined, InvalidExpression, AttributeDoesNotExist, simple_eval
 
 class DRYTest(unittest.TestCase):
     ''' Stuff we need to do every test, let's do here instead..
@@ -226,6 +226,11 @@ class TestNames(DRYTest):
         with self.assertRaises(InvalidExpression):
             self.t('s', 21)
 
+        self.s.names = {'a' : {'b': {'c': 42}}}
+
+        with self.assertRaises(AttributeDoesNotExist):
+            self.t('a.b.d**2', 42)
+
 
     def test_dict(self):
         ''' using a normal dict for names lookup '''
@@ -277,6 +282,21 @@ class TestNames(DRYTest):
 
         self.assertEqual(self.s.names['c']['c']['c'], 11)
 
+        # nested dict
+
+        self.s.names = {'a' : {'b': {'c': 42}}}
+
+        self.t("a.b.c*2", 84)
+
+        self.t("a.b.c = 11", 11)
+
+        self.assertEqual(self.s.names['a']['b']['c'], 42)
+
+        self.t("a.d = 11", 11)
+
+        with self.assertRaises(KeyError):
+            self.assertEqual(self.s.names['a']['d'], 11)
+
     def test_func(self):
         ''' using a function for 'names lookup' '''
 
@@ -319,3 +339,6 @@ class Test_simple_eval(unittest.TestCase):
     def test_default_functions(self):
         self.assertEqual(simple_eval('rand() < 1.0 and rand() > -0.01'), True)
         self.assertEqual(simple_eval('randint(200) < 200 and rand() > 0'), True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,

Thanks for the useful code. I added support for nested dicts such that this can be evaluated:
simpleeval('a.b.c*2', names={'a' : {'b': {'c': 42}}})

Hope you accept this change.

Regards,
-dave