### PR TITLE
Add Support For Slicing

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -285,7 +285,6 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
         elif isinstance(node, ast.Index):
             return self._eval(node.value)
         elif isinstance(node, ast.Slice):
-            print("Was slick!")
             lower = upper = step = None
             if node.lower is not None:
                 lower = self._eval(node.lower)

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -275,8 +275,34 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
                 raise NameNotDefined(node.id, self.expr)
 
         elif isinstance(node, ast.Subscript): # b[1]
-            return self._eval(node.value)[self._eval(node.slice.value)]
-
+            return self._eval(node.value)[self._eval(node.slice)]
+        elif isinstance(node, ast.Index):
+            return self._eval(node.value)
+        elif isinstance(node, ast.Slice):
+            #If it has this, it must be a true slice (i.e. of the form x[1:2:3])
+            if hasattr(node, "lower"):
+                lower = upper = step = None
+                if node.lower is not None:
+                    if isinstance(node.lower, ast.Name):
+                        if node.lower.id != "None":
+                            lower = self._eval(node.lower)
+                    else:
+                        lower = self._eval(node.lower)
+                if node.upper is not None:
+                    if isinstance(node.upper, ast.Name):
+                        if node.upper.id != "None":
+                            upper = self._eval(node.upper)
+                    else:
+                        upper = self._eval(node.upper)
+                if node.step is not None:
+                    if isinstance(node.step, ast.Name):
+                        if node.step.id != "None":
+                            step = self._eval(node.step)
+                    else:
+                        step = self._eval(node.step)
+                return slice(lower, upper, step)
+            else:
+                return self._eval(node.value)
         else:
             raise FeatureNotAvailable("Sorry, {0} is not available in this "
                                       "evaluator".format(type(node).__name__ ))

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -262,7 +262,13 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
 
         elif isinstance(node, ast.Name): # a, b, c...
             try:
-                if isinstance(self.names, dict):
+                #This happens at least for slicing
+                #This is a safe thing to do because it is impossible
+                #that there is a true exression assigning to none
+                #(the compiler rejects it, so you can't even pass that to ast.parse)
+                if node.id == "None":
+                    return None
+                elif isinstance(self.names, dict):
                     return self.names[node.id]
                 elif callable(self.names):
                     return self.names(node)
@@ -283,23 +289,11 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
             if hasattr(node, "lower"):
                 lower = upper = step = None
                 if node.lower is not None:
-                    if isinstance(node.lower, ast.Name):
-                        if node.lower.id != "None":
-                            lower = self._eval(node.lower)
-                    else:
-                        lower = self._eval(node.lower)
+                    lower = self._eval(node.lower)
                 if node.upper is not None:
-                    if isinstance(node.upper, ast.Name):
-                        if node.upper.id != "None":
-                            upper = self._eval(node.upper)
-                    else:
-                        upper = self._eval(node.upper)
+                    upper = self._eval(node.upper)
                 if node.step is not None:
-                    if isinstance(node.step, ast.Name):
-                        if node.step.id != "None":
-                            step = self._eval(node.step)
-                    else:
-                        step = self._eval(node.step)
+                    step = self._eval(node.step)
                 return slice(lower, upper, step)
             else:
                 return self._eval(node.value)

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -285,18 +285,15 @@ class SimpleEval(object): # pylint: disable=too-few-public-methods
         elif isinstance(node, ast.Index):
             return self._eval(node.value)
         elif isinstance(node, ast.Slice):
-            #If it has this, it must be a true slice (i.e. of the form x[1:2:3])
-            if hasattr(node, "lower"):
-                lower = upper = step = None
-                if node.lower is not None:
-                    lower = self._eval(node.lower)
-                if node.upper is not None:
-                    upper = self._eval(node.upper)
-                if node.step is not None:
-                    step = self._eval(node.step)
-                return slice(lower, upper, step)
-            else:
-                return self._eval(node.value)
+            print("Was slick!")
+            lower = upper = step = None
+            if node.lower is not None:
+                lower = self._eval(node.lower)
+            if node.upper is not None:
+                upper = self._eval(node.upper)
+            if node.step is not None:
+                step = self._eval(node.step)
+            return slice(lower, upper, step)
         else:
             raise FeatureNotAvailable("Sorry, {0} is not available in this "
                                       "evaluator".format(type(node).__name__ ))

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -7,7 +7,7 @@
 '''
 # pylint: disable=too-many-public-methods, missing-docstring
 
-import unittest
+import unittest, operator, ast
 import simpleeval
 from simpleeval import SimpleEval, NameNotDefined, InvalidExpression, simple_eval
 
@@ -85,6 +85,23 @@ class TestBasic(DRYTest):
         self.t('int("20") + int(0.22*100)', 42)
         self.t('float("42")', 42.0)
         self.t('"Test Stuff!" + str(11)', u"Test Stuff!11")
+
+    def test_slicing(self):
+        self.s.operators[ast.Slice] = operator.getslice if hasattr(operator, "getslice") else operator.getitem
+        self.t("'hello'[1]", "e")
+        self.t("'hello'[:]", "hello")
+        self.t("'hello'[:3]", "hel")
+        self.t("'hello'[3:]", "lo")
+        self.t("'hello'[::2]", "hlo")
+        self.t("'hello'[::-1]", "olleh")
+        self.t("'hello'[3::]", "lo")
+        self.t("'hello'[:3:]", "hel")
+        self.t("'hello'[1:3]", "el")
+        self.t("'hello'[1:3:]", "el")
+        self.t("'hello'[1::2]", "el")
+        self.t("'hello'[:1:2]", "h")
+        self.t("'hello'[1:3:1]", "el")
+        self.t("'hello'[1:3:2]", "e")
 
 class TestFunctions(DRYTest):
     ''' Functions for expressions to play with '''


### PR DESCRIPTION
The current indexing support (when enabled) only works for lone indices. This changeset adds support for all forms of slicing. (It still isn't enabled by default. Why is indexing not enabled by default anyway?)