### PR TITLE
Create an Expr class to parse and save the AST, allowing retrieving the list of names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 dist
 MANIFEST
 .idea
+
+testfile.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	python test_simpleeval.py
+.PHONY: test

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ simpleeval (Simple Eval)
 .. image:: https://travis-ci.org/danthedeckie/simpleeval.svg?branch=master
    :target: https://travis-ci.org/danthedeckie/simpleeval
    :alt: Build Status
-   
+
 .. image:: https://coveralls.io/repos/github/danthedeckie/simpleeval/badge.svg?branch=master
    :target: https://coveralls.io/r/danthedeckie/simpleeval?branch=master
    :alt: Coverage Status
@@ -185,7 +185,7 @@ which, of course, can be nested:
 
     >>> simple_eval("'a' if 1 == 2 else 'b' if 2 == 3 else 'c'")
     'c'
-    
+
 
 Functions
 ---------
@@ -278,7 +278,7 @@ cases):
 
     >>> s.eval('100 * 10')
     1000
-    
+
     # and so on...
 
 You can assign / edit the various options of the ``SimpleEval`` object if you
@@ -355,3 +355,10 @@ If you really need that (BE CAREFUL!), then modify the module global
 Please read the ``test_simpleeval.py`` file for other potential gotchas or
 details.  I'm very happy to accept pull requests, suggestions, or other issues.
 Enjoy!
+
+Developing
+----------
+
+Run tests::
+
+    $ make test

--- a/README.rst
+++ b/README.rst
@@ -316,6 +316,32 @@ Say.  This would allow a certain level of 'scriptyness' if you had these
 evaluations happening as callbacks in a program.  Although you really are
 reaching the end of what this library is intended for at this stage.
 
+Creating an expression instance
+-------------------------------
+
+Creating an expression class can make sense if you want to inspect the parsed
+expression (e.g. to get the names defined) or if parsing the expression is
+costly.
+
+.. code-block:: python
+
+    expr = simpleeval.Expr("2 + 2")  # the AST is parsed at this time
+    assert expr.eval() == 2
+
+    expr = simpleeval.Expr("a + 1")
+    assert expr.get_names() == set(["a"])  # returns the set of names
+    assert expr.eval(names={"a": 1}) == 2
+
+You can also pass a specific evaluator class to further customize the parsing
+environment.
+
+.. code-block:: python
+
+    from simpleeval import EvalWithCompoundTypes, Expr
+
+    expr = Expr("[1, 2][0]", evaluator_cls=EvalWithCompoundTypes)
+    assert expr.eval() == 1
+
 Compound Types
 --------------
 

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -10,6 +10,7 @@
 import unittest
 import operator
 import ast
+
 import simpleeval
 from simpleeval import (
     SimpleEval, EvalWithCompoundTypes, FeatureNotAvailable, FunctionNotDefined, NameNotDefined,
@@ -663,6 +664,30 @@ class TestSimpleEval(unittest.TestCase):
     def test_default_functions(self):
         self.assertEqual(simple_eval('rand() < 1.0 and rand() > -0.01'), True)
         self.assertEqual(simple_eval('randint(200) < 200 and rand() > 0'), True)
+
+
+class TestExpr(unittest.TestCase):
+    """Verify that we can parse an expression and evaluate it later."""
+
+    def test_parse_and_eval(self):
+        expr = simpleeval.Expr("200 + 200")
+        self.assertEqual(expr.eval(), 400)
+
+    def test_parse_and_eval_with_custom_cls(self):
+        expr = simpleeval.Expr("[1, 2][0]", evaluator_cls=EvalWithCompoundTypes)
+        self.assertEqual(expr.eval(), 1)
+
+    def test_parse_and_eval_with_names(self):
+        expr = simpleeval.Expr("a + 200")
+        self.assertEqual(expr.eval(names={"a": 200}), 400)
+
+    def test_get_names(self):
+        expr = simpleeval.Expr("a + 200")
+        self.assertEqual(expr.get_names(), set(["a"]))
+
+    def test_get_names_complex(self):
+        expr = simpleeval.Expr("a.b.c + int(e) / d.method() and (a and e)")
+        self.assertEqual(expr.get_names(), set(["a", "e", "d"]))
 
 
 class TestExtendingClass(unittest.TestCase):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -162,7 +162,7 @@ class TestFunctions(DRYTest):
 
         # write to the file:
 
-        with open("file.txt", 'w') as f:
+        with open("testfile.txt", 'w') as f:
             f.write("42")
 
         # define the function we'll send to the eval'er
@@ -175,12 +175,12 @@ class TestFunctions(DRYTest):
         # simple load:
 
         self.s.functions = {"read": load_file}
-        self.t("read('file.txt')", "42")
+        self.t("read('testfile.txt')", "42")
 
         # and we should have *replaced* the default functions. Let's check:
 
         with self.assertRaises(simpleeval.FunctionNotDefined):
-            self.t("int(read('file.txt'))", 42)
+            self.t("int(read('testfile.txt'))", 42)
 
         # OK, so we can load in the default functions as well...
 
@@ -188,7 +188,7 @@ class TestFunctions(DRYTest):
 
         # now it works:
 
-        self.t("int(read('file.txt'))", 42)
+        self.t("int(read('testfile.txt'))", 42)
 
     def test_randoms(self):
         """ test the rand() and randint() functions """
@@ -687,3 +687,6 @@ class TestExtendingClass(unittest.TestCase):
 
         with self.assertRaises(simpleeval.FeatureNotAvailable):
             e.eval('"  blah  ".strip()')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is based on #35. It adds some extra functionality:

* You can now save the generated AST by using the `Expr` class.
* You can now get the list of first-level names defined in the AST. This is useful if you want to get an idea of the names you'll have to provide or to define the dependencies of an expression.

The current implementation is not super efficient because an evaluator instance is created for each evaluation. Let me know if this should be fixed in this PR. 