### PR TITLE
Add f-string parsing and EvalWithAssignments

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -274,7 +274,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
 
         # py3.6
         if hasattr(ast, 'JoinedStr'):
-            self.nodes[ast.JoinedStr] = self._eval_joinedstr,  # f-string
+            self.nodes[ast.JoinedStr] = self._eval_joinedstr  # f-string
             self.nodes[ast.FormattedValue] = self._eval_formattedvalue  # formatted value in f-string
 
     def eval(self, expr):

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -258,9 +258,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.Subscript: self._eval_subscript,
             ast.Attribute: self._eval_attribute,
             ast.Index: self._eval_index,
-            ast.Slice: self._eval_slice,
-            ast.JoinedStr: self._eval_joinedstr,  # f-string
-            ast.FormattedValue: self._eval_formattedvalue  # formatted value in f-string
+            ast.Slice: self._eval_slice
         }
 
         # py3k stuff:
@@ -268,6 +266,11 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             self.nodes[ast.NameConstant] = self._eval_nameconstant
         elif isinstance(self.names, dict) and "None" not in self.names:
             self.names["None"] = None
+
+        # py3.6
+        if hasattr(ast, 'JoinedStr'):
+            self.nodes[ast.JoinedStr] = self._eval_joinedstr,  # f-string
+            self.nodes[ast.FormattedValue] = self._eval_formattedvalue  # formatted value in f-string
 
     def eval(self, expr):
         """ evaluate an expresssion, using the operators, functions and

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -518,10 +518,10 @@ class EvalWithAssignments(SimpleEval):
         if isinstance(names, ast.Tuple):  # unpacking variables
             names = [n.id for n in names.elts]  # turn ast into str
             if not isinstance(values, ast.Tuple):
-                raise ValueError(f"unequal unpack: {len(names)} names, 1 value")
+                raise ValueError("unequal unpack: {} names, 1 value".format(len(names)))
             values = values.elts
             if not len(values) == len(names):
-                raise ValueError(f"unequal unpack: {len(names)} names, {len(values)} values")
+                raise ValueError("unequal unpack: {} names, {} values".format(len(names), len(values)))
             else:
                 if not isinstance(self.names, dict):
                     raise TypeError("cannot set name: incorrect name type")

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -83,8 +83,8 @@ well:
 """
 
 import ast
-import sys
 import operator as op
+import sys
 from random import random
 
 ########################################
@@ -97,6 +97,7 @@ DISALLOW_METHODS = ['format']
 
 PYTHON3 = sys.version_info[0] == 3
 
+
 ########################################
 # Exceptions:
 
@@ -108,6 +109,7 @@ class InvalidExpression(Exception):
 
 class FunctionNotDefined(InvalidExpression):
     """ sorry! That function isn't defined! """
+
     def __init__(self, func_name, expression):
         self.message = "Function '{0}' not defined," \
                        " for expression '{1}'.".format(func_name, expression)
@@ -120,6 +122,7 @@ class FunctionNotDefined(InvalidExpression):
 
 class NameNotDefined(InvalidExpression):
     """ a name isn't defined. """
+
     def __init__(self, name, expression):
         self.name = name
         self.message = "'{0}' is not defined for expression '{1}'".format(
@@ -132,6 +135,7 @@ class NameNotDefined(InvalidExpression):
 
 class AttributeDoesNotExist(InvalidExpression):
     """attribute does not exist"""
+
     def __init__(self, attr, expression):
         self.message = \
             "Attribute '{0}' does not exist in expression '{1}'".format(
@@ -176,9 +180,9 @@ def safe_power(a, b):  # pylint: disable=invalid-name
 def safe_mult(a, b):  # pylint: disable=invalid-name
     """ limit the number of times an iterable can be repeated... """
 
-    if hasattr(a, '__len__') and b*len(a) > MAX_STRING_LENGTH:
+    if hasattr(a, '__len__') and b * len(a) > MAX_STRING_LENGTH:
         raise IterableTooLong('Sorry, I will not evalute something that long.')
-    if hasattr(b, '__len__') and a*len(b) > MAX_STRING_LENGTH:
+    if hasattr(b, '__len__') and a * len(b) > MAX_STRING_LENGTH:
         raise IterableTooLong('Sorry, I will not evalute something that long.')
 
     return a * b
@@ -215,6 +219,7 @@ DEFAULT_FUNCTIONS = {"rand": random, "randint": random_int,
                      "str": str if PYTHON3 else unicode}
 
 DEFAULT_NAMES = {"True": True, "False": False}
+
 
 ########################################
 # And the actual evaluator:
@@ -303,7 +308,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         if len(node.s) > MAX_STRING_LENGTH:
             raise IterableTooLong("String Literal in statement is too long!"
                                   " ({0}, when {1} is max)".format(
-                                      len(node.s), MAX_STRING_LENGTH))
+                len(node.s), MAX_STRING_LENGTH))
         return node.s
 
     @staticmethod
@@ -344,7 +349,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
 
     def _eval_ifexp(self, node):
         return self._eval(node.body) if self._eval(node.test) \
-                                         else self._eval(node.orelse)
+            else self._eval(node.orelse)
 
     def _eval_call(self, node):
         if isinstance(node.func, ast.Attribute):
@@ -403,8 +408,8 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
                     "({0})".format(node.attr))
         if node.attr in DISALLOW_METHODS:
             raise FeatureNotAvailable(
-                    "Sorry, this method is not available. "
-                    "({0})".format(node.attr))
+                "Sorry, this method is not available. "
+                "({0})".format(node.attr))
 
         try:
             return self._eval(node.value)[node.attr]
@@ -487,6 +492,7 @@ class EvalWithAssignments(SimpleEval):
     """
     SimpleEval, but allows the setting of evaluator's names with name=value.
     """
+
     def __init__(self, operators=None, functions=None, names=None):
         super(SimpleEval, self).__init__(operators, functions, names)
 

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -488,13 +488,13 @@ class EvalWithCompoundTypes(SimpleEval):
         return set(self._eval(x) for x in node.elts)
 
 
-class EvalWithAssignments(SimpleEval):
+class EvalWithAssignments(EvalWithCompoundTypes):
     """
     SimpleEval, but allows the setting of evaluator's names with name=value.
     """
 
     def __init__(self, operators=None, functions=None, names=None):
-        super(SimpleEval, self).__init__(operators, functions, names)
+        super(EvalWithAssignments, self).__init__(operators, functions, names)
 
     def eval(self, expr):  # allow for ast.Assign to set names
         """ evaluate an expression, using the operators, functions and
@@ -527,12 +527,12 @@ class EvalWithAssignments(SimpleEval):
                     raise TypeError("cannot set name: incorrect name type")
                 else:
                     for name, value in zip(names, values):
-                        self.names[name] = value  # and assign it
+                        self.names[name] = self._eval(value)  # and assign it
         else:
             if not isinstance(self.names, dict):
                 raise TypeError("cannot set name: incorrect name type")
             else:
-                self.names[names.id] = values
+                self.names[names.id] = self._eval(values)
 
 
 def simple_eval(expr, operators=None, functions=None, names=None):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -547,6 +547,9 @@ class TestAssignments(DRYTest):
 class TestNames(DRYTest):
     """ 'names', what other languages call variables... """
 
+    def setUp(self):
+        self.s = EvalWithCompoundTypes()
+
     def test_none(self):
         """ what to do when names isn't defined, or is 'none' """
         with self.assertRaises(NameNotDefined):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -533,16 +533,15 @@ class TestAssignments(DRYTest):
         with self.assertRaises(ValueError):
             self.t('a,b=1,2,3', None)
         self.t('a=1,2,3', None)
-        self.t('a', (1,2,3))
+        self.t('a', (1, 2, 3))
 
     def test_names_function(self):
-        oldnames = self.s.names
         self.s.names = lambda n: n  # each name's value is just the name
         with self.assertRaises(TypeError):
             self.t('a,b=1,2', None)
         with self.assertRaises(TypeError):
             self.t('a=2', None)
-        self.s.names = oldnames
+        self.s.names = {}  # clean up for later tests
 
 
 class TestNames(DRYTest):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -13,7 +13,7 @@ import unittest
 
 import simpleeval
 from simpleeval import (
-    SimpleEval, EvalWithCompoundTypes, FeatureNotAvailable, FunctionNotDefined, NameNotDefined,
+    SimpleEval, EvalWithCompoundTypes, EvalWithAssignments, FeatureNotAvailable, FunctionNotDefined, NameNotDefined,
     InvalidExpression, AttributeDoesNotExist, simple_eval
 )
 
@@ -495,6 +495,54 @@ class TestCompoundTypes(DRYTest):
 
         self.s = EvalWithCompoundTypes(functions={"dir": dir, "str": str})
         self.t('dir(str)', dir(str))
+
+
+class TestAssignments(DRYTest):
+    """ Test the assignment edition of the library """
+
+    def setUp(self):
+        self.s = EvalWithAssignments()
+
+    def test_assign(self):
+        self.t('a=1', None)
+        self.t('a', 1)
+
+    def test_reassign(self):
+        self.t('a=1', None)
+        self.t('a', 1)
+        self.t('a=2', None)
+        self.t('a', 2)
+
+    def test_assign_complex(self):
+        self.t('a=1+1+2', None)
+        self.t('a', 4)
+        self.t('b=15**2', None)
+        self.t('b', 225)
+        self.t('c=a+b', None)
+        self.t('c', 229)
+
+    def test_unpack(self):
+        self.t('a,b,c=1,2,3', None)
+        self.t('a', 1)
+        self.t('b', 2)
+        self.t('c', 3)
+
+    def test_unequal_unpack(self):
+        with self.assertRaises(ValueError):
+            self.t('a,b=1', None)
+        with self.assertRaises(ValueError):
+            self.t('a,b=1,2,3', None)
+        self.t('a=1,2,3', None)
+        self.t('a', (1,2,3))
+
+    def test_names_function(self):
+        oldnames = self.s.names
+        self.s.names = lambda n: n  # each name's value is just the name
+        with self.assertRaises(TypeError):
+            self.t('a,b=1,2', None)
+        with self.assertRaises(TypeError):
+            self.t('a=2', None)
+        self.s.names = oldnames
 
 
 class TestNames(DRYTest):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -497,53 +497,6 @@ class TestCompoundTypes(DRYTest):
         self.t('dir(str)', dir(str))
 
 
-class TestAssignments(DRYTest):
-    """ Test the assignment edition of the library """
-
-    def setUp(self):
-        self.s = EvalWithAssignments()
-
-    def test_assign(self):
-        self.t('a=1', None)
-        self.t('a', 1)
-
-    def test_reassign(self):
-        self.t('a=1', None)
-        self.t('a', 1)
-        self.t('a=2', None)
-        self.t('a', 2)
-
-    def test_assign_complex(self):
-        self.t('a=1+1+2', None)
-        self.t('a', 4)
-        self.t('b=15**2', None)
-        self.t('b', 225)
-        self.t('c=a+b', None)
-        self.t('c', 229)
-
-    def test_unpack(self):
-        self.t('a,b,c=1,2,3', None)
-        self.t('a', 1)
-        self.t('b', 2)
-        self.t('c', 3)
-
-    def test_unequal_unpack(self):
-        with self.assertRaises(ValueError):
-            self.t('a,b=1', None)
-        with self.assertRaises(ValueError):
-            self.t('a,b=1,2,3', None)
-        self.t('a=1,2,3', None)
-        self.t('a', (1, 2, 3))
-
-    def test_names_function(self):
-        self.s.names = lambda n: n  # each name's value is just the name
-        with self.assertRaises(TypeError):
-            self.t('a,b=1,2', None)
-        with self.assertRaises(TypeError):
-            self.t('a=2', None)
-        self.s.names = {}  # clean up for later tests
-
-
 class TestNames(DRYTest):
     """ 'names', what other languages call variables... """
 
@@ -693,6 +646,53 @@ class TestNames(DRYTest):
         self.s.names = name_handler
         self.t('a', 1)
         self.t('a + b', 3)
+
+
+class TestAssignments(DRYTest):
+    """ Test the assignment edition of the library """
+
+    def setUp(self):
+        self.s = EvalWithAssignments()
+
+    def test_assign(self):
+        self.t('a=1', None)
+        self.t('a', 1)
+
+    def test_reassign(self):
+        self.t('a=1', None)
+        self.t('a', 1)
+        self.t('a=2', None)
+        self.t('a', 2)
+
+    def test_assign_complex(self):
+        self.t('a=1+1+2', None)
+        self.t('a', 4)
+        self.t('b=15**2', None)
+        self.t('b', 225)
+        self.t('c=a+b', None)
+        self.t('c', 229)
+
+    def test_unpack(self):
+        self.t('a,b,c=1,2,3', None)
+        self.t('a', 1)
+        self.t('b', 2)
+        self.t('c', 3)
+
+    def test_unequal_unpack(self):
+        with self.assertRaises(ValueError):
+            self.t('a,b=1', None)
+        with self.assertRaises(ValueError):
+            self.t('a,b=1,2,3', None)
+        self.t('a=1,2,3', None)
+        self.t('a', (1, 2, 3))
+
+    def test_names_function(self):
+        self.s.names = lambda n: n  # each name's value is just the name
+        with self.assertRaises(TypeError):
+            self.t('a,b=1,2', None)
+        with self.assertRaises(TypeError):
+            self.t('a=2', None)
+        self.s.names = {}  # clean up for later tests
 
 
 class TestWhitespace(DRYTest):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -153,6 +153,13 @@ class TestBasic(DRYTest):
         self.t('1 is not None', True)
         self.t('None is not None', False)
 
+    def test_fstring(self):
+        self.t('f""', "")
+        self.t('f"stuff"', "stuff")
+        self.t('f"one is {1} and two is {2}"', "one is 1 and two is 2")
+        self.t('f"1+1 is {1+1}"', "1+1 is 2")
+        self.t('f"{\'dramatic\':!<11}"', "dramatic!!!")
+
 
 class TestFunctions(DRYTest):
     """ Functions for expressions to play with """
@@ -324,6 +331,9 @@ class TestTryingToBreakOut(DRYTest):
 
         with self.assertRaises(simpleeval.IterableTooLong):
             self.t("'" + (50000 * "stuff") + "'", 0)
+
+        with self.assertRaises(simpleeval.IterableTooLong):
+            self.t("f'{\"foo\"*50000}'", 0)
 
     def test_bytes_array_test(self):
         self.t("'20000000000000000000'.encode() * 5000",

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -334,8 +334,9 @@ class TestTryingToBreakOut(DRYTest):
         with self.assertRaises(simpleeval.IterableTooLong):
             self.t("'" + (50000 * "stuff") + "'", 0)
 
-        with self.assertRaises(simpleeval.IterableTooLong):
-            self.t("f'{\"foo\"*50000}'", 0)
+        if sys.version_info >= (3, 6, 0):
+            with self.assertRaises(simpleeval.IterableTooLong):
+                self.t("f'{\"foo\"*50000}'", 0)
 
     def test_bytes_array_test(self):
         self.t("'20000000000000000000'.encode() * 5000",

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -5,11 +5,12 @@
     Most of this stuff is pretty basic.
 
 """
-# pylint: disable=too-many-public-methods, missing-docstring
-
-import unittest
-import operator
 import ast
+import operator
+# pylint: disable=too-many-public-methods, missing-docstring
+import sys
+import unittest
+
 import simpleeval
 from simpleeval import (
     SimpleEval, EvalWithCompoundTypes, FeatureNotAvailable, FunctionNotDefined, NameNotDefined,
@@ -154,11 +155,12 @@ class TestBasic(DRYTest):
         self.t('None is not None', False)
 
     def test_fstring(self):
-        self.t('f""', "")
-        self.t('f"stuff"', "stuff")
-        self.t('f"one is {1} and two is {2}"', "one is 1 and two is 2")
-        self.t('f"1+1 is {1+1}"', "1+1 is 2")
-        self.t('f"{\'dramatic\':!<11}"', "dramatic!!!")
+        if sys.version_info >= (3, 6, 0):
+            self.t('f""', "")
+            self.t('f"stuff"', "stuff")
+            self.t('f"one is {1} and two is {2}"', "one is 1 and two is 2")
+            self.t('f"1+1 is {1+1}"', "1+1 is 2")
+            self.t('f"{\'dramatic\':!<11}"', "dramatic!!!")
 
 
 class TestFunctions(DRYTest):
@@ -406,11 +408,11 @@ class TestTryingToBreakOut(DRYTest):
             self.t("True.__class__.__class__.__base__.__subclasses__()[-1]"
                    ".__init__.func_globals['sys'].exit(1)", 42)
 
-
     def test_string_format(self):
         # python has so many ways to break out!
         with self.assertRaises(simpleeval.FeatureNotAvailable):
-             self.t('"{string.__class__}".format(string="things")', 0)
+            self.t('"{string.__class__}".format(string="things")', 0)
+
 
 class TestCompoundTypes(DRYTest):
     """ Test the compound-types edition of the library """


### PR DESCRIPTION
f-string parsing: A feature added with Python 3.6. Does not appear to have the vulnerabilities found in str.format().  
EvalWithAssignments: A demonstration of how to use the ast.Assign body to assign values to names in the evaluator.

Additionally, I ran a formatting pass on the main file (out of habit, PyCharm's autoformat button is too alluring ;D)