### PR TITLE
A fix for the weird behaviour with class method chaining

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -400,15 +400,17 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             raise FeatureNotAvailable(
                     "Sorry, this method is not available. "
                     "({0})".format(node.attr))
+        # eval node
+        node_evaulated = self._eval(node.value)
 
         try:
-            return self._eval(node.value)[node.attr]
+            return node_evaulated[node.attr]
         except (KeyError, TypeError):
             pass
 
         # Maybe the base object is an actual object, not just a dict
         try:
-            return getattr(self._eval(node.value), node.attr)
+            return getattr(node_evaulated, node.attr)
         except (AttributeError, TypeError):
             pass
 


### PR DESCRIPTION
Hello,
This is a fix for issue #39, 
I was trying to evaluate some method calls using the **method chaining** syntax, but simpleeval returned weird results:
```python
x = A()
print(simpleeval.simple_eval("x.add(1).sub(2).sub(3)", names={"x": x}))
```
I got `0-add1-add1-sub2-add1-add1-sub2-sub3` instead of: ` 0-add1-sub2-sub3`

After debugging the code, I found that **_eval_attribute** method will evaluate **node.value** two times if it fails to get the attribute using only brackets (calling `__get__` ).

As a fix, the code should first evaluate the value node before trying to get its attribute:
```python
        # eval node
        node_evaulated = self._eval(node.value)

        try:
            return node_evaulated[node.attr]
        except (KeyError, TypeError):
            pass

        # Maybe the base object is an actual object, not just a dict
        try:
            return getattr(node_evaulated, node.attr)
        except (AttributeError, TypeError):
            pass
```