### PR TITLE
Boolean And should return first falsey value

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -367,7 +367,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             for value in node.values:
                 vout = self._eval(value)
                 if not vout:
-                    return False
+                    return vout
             return vout
         elif isinstance(node.op, ast.Or):
             for value in node.values:

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -46,7 +46,7 @@ class TestBasic(DRYTest):
         self.t("100 % 9", 1)
 
     def test_bools_and_or(self):
-        self.t('True and 0', 0)
+        self.t('True and ""', "")
         self.t('True and False', False)
         self.t('True or False', True)
         self.t('False or False', False)

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -46,6 +46,7 @@ class TestBasic(DRYTest):
         self.t("100 % 9", 1)
 
     def test_bools_and_or(self):
+        self.t('True and 0', 0)
         self.t('True and False', False)
         self.t('True or False', True)
         self.t('False or False', False)


### PR DESCRIPTION
I think boolean `And` should return the first falsey result like python and not literal `False`:
```
>>> True and [] and True
[]
```