### PR TITLE
Cache ast parsed expressions

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -279,6 +279,8 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         self.functions = functions
         self.names = names
 
+        self.previously_parsed_expressions = {}
+
         self.nodes = {
             ast.Num: self._eval_num,
             ast.Str: self._eval_str,
@@ -325,7 +327,16 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         self.expr = expr
 
         # and evaluate:
-        return self._eval(ast.parse(expr.strip()).body[0].value)
+        stripped_expr = expr.strip()
+        previously_parsed_ast = self.previously_parsed_expressions.get(stripped_expr)
+        if previously_parsed_ast:
+            # Return previously ast parsed expression if seen before
+            return self._eval(previously_parsed_ast)
+
+        # Add to previously_parsed_ast if not seen before
+        ast_parsed_expr = ast.parse(stripped_expr).body[0].value
+        self.previously_parsed_expressions[stripped_expr] = ast_parsed_expr
+        return self._eval(ast_parsed_expr)
 
     def _eval(self, node):
         """ The internal evaluator used on each node in the parsed tree. """


### PR DESCRIPTION
Should allow the use cases outlined in https://github.com/danthedeckie/simpleeval/issues/25
Basically the expressions that have already gone through `ast.parse` are cached in the SimpleEval class.  Whenever `eval` is called it checks if the expression had been parsed previously.  If so it will used the previously `ast.parse` result that was run on the expression the first time it ran.

If you agree with this PR for this use case I will add tests for this feature (also might be worth adding some LRU type configurable logic...).  If not I think that the _eval function should be renamed to something like `eval_ast`  to signify that it is a public method that can be used to cover use cases like those in the linked issues.

Either way let me know what you think