### PR TITLE
Expand comprehension support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build
 dist
 MANIFEST
 .idea
+venv
 
 testfile.txt

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -524,6 +524,8 @@ class EvalWithCompoundTypes(SimpleEval):
             ast.List: self._eval_list,
             ast.Set: self._eval_set,
             ast.ListComp: self._eval_listcomp,
+            ast.SetComp: self._eval_setcomp,
+            ast.DictComp: self._eval_dictcomp,
             ast.GeneratorExp: self._eval_generatorexp,
         })
 
@@ -546,6 +548,12 @@ class EvalWithCompoundTypes(SimpleEval):
 
     def _eval_listcomp(self, node):
         return list(self._do_comprehension(node))
+
+    def _eval_setcomp(self, node):
+        return set(self._do_comprehension(node))
+
+    def _eval_dictcomp(self, node):
+        return dict(self._do_comprehension(node, is_dictcomp=True))
 
     def _eval_generatorexp(self, node):
         for item in self._do_comprehension(node):

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -308,7 +308,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         # Defaults:
 
         self.ATTR_INDEX_FALLBACK = ATTR_INDEX_FALLBACK
-        
+
         # Check for forbidden functions:
 
         for f in self.functions.values():
@@ -523,8 +523,8 @@ class EvalWithCompoundTypes(SimpleEval):
             ast.Tuple: self._eval_tuple,
             ast.List: self._eval_list,
             ast.Set: self._eval_set,
-            ast.ListComp: self._eval_comprehension,
-            ast.GeneratorExp: self._eval_comprehension,
+            ast.ListComp: self._eval_listcomp,
+            ast.GeneratorExp: self._eval_generatorexp,
         })
 
     def eval(self, expr):
@@ -544,11 +544,22 @@ class EvalWithCompoundTypes(SimpleEval):
     def _eval_set(self, node):
         return set(self._eval(x) for x in node.elts)
 
-    def _eval_comprehension(self, node):
-        to_return = []
+    def _eval_listcomp(self, node):
+        return list(self._do_comprehension(node))
+
+    def _eval_generatorexp(self, node):
+        for item in self._do_comprehension(node):
+            yield item
+
+    def _do_comprehension(self, comprehension_node, is_dictcomp=False):
+        if is_dictcomp:
+            def do_value(node):
+                return self._eval(node.key), self._eval(node.value)
+        else:
+            def do_value(node):
+                return self._eval(node.elt)
 
         extra_names = {}
-
         previous_name_evaller = self.nodes[ast.Name]
 
         def eval_names_extra(node):
@@ -573,25 +584,34 @@ class EvalWithCompoundTypes(SimpleEval):
                     recurse_targets(t, v)
 
         def do_generator(gi=0):
-            g = node.generators[gi]
-            for i in self._eval(g.iter):
+            """
+            For each generator, set the names used in the final emitted value/the next generator.
+            Only the final generator (gi = len(comprehension_node.generator)-1) should emit the final values,
+            since only then are all possible necessary values set in extra_names.
+            """
+            generator_node = comprehension_node.generators[gi]
+            for i in self._eval(generator_node.iter):
                 self._max_count += 1
-
                 if self._max_count > MAX_COMPREHENSION_LENGTH:
                     raise IterableTooLong('Comprehension generates too many elements')
-                recurse_targets(g.target, i)
-                if all(self._eval(iff) for iff in g.ifs):
-                    if len(node.generators) > gi + 1:
-                        do_generator(gi+1)
+
+                # set names
+                recurse_targets(generator_node.target, i)
+
+                if all(self._eval(iff) for iff in generator_node.ifs):
+                    if len(comprehension_node.generators) > gi + 1:
+                        # next generator
+                        for v in do_generator(gi + 1):  # bubble up emitted values
+                            yield v
                     else:
-                        to_return.append(self._eval(node.elt))
+                        # emit values
+                        yield do_value(comprehension_node)
 
         try:
-            do_generator()
+            for item in do_generator():
+                yield item
         finally:
             self.nodes.update({ast.Name: previous_name_evaller})
-
-        return to_return
 
 
 def simple_eval(expr, operators=None, functions=None, names=None):

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -630,11 +630,15 @@ class TestComprehensions(DRYTest):
         with self.assertRaises(simpleeval.IterableTooLong):
             self.s.eval(s)
 
+        # ensure we didn't actually run more than necessary
+        assert self.s._max_count == simpleeval.MAX_COMPREHENSION_LENGTH + 1
+
     def test_too_long_generator_2(self):
         self.s.functions = {'range': range}
         s = '[j for i in range(100) if i > 1 for j in range(i+10) if j < 100 for k in range(i*j)]'
         with self.assertRaises(simpleeval.IterableTooLong):
             self.s.eval(s)
+        assert self.s._max_count == simpleeval.MAX_COMPREHENSION_LENGTH + 1
 
     def test_nesting_generators_to_cheat(self):
         self.s.functions = {'range': range}
@@ -642,6 +646,7 @@ class TestComprehensions(DRYTest):
 
         with self.assertRaises(simpleeval.IterableTooLong):
             self.s.eval(s)
+        assert self.s._max_count == simpleeval.MAX_COMPREHENSION_LENGTH + 1
 
     def test_no_leaking_names(self):
         # see issue #52, failing list comprehensions could leak locals

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -582,25 +582,50 @@ class TestComprehensions(DRYTest):
 
     def test_basic(self):
         self.t('[a + 1 for a in [1,2,3]]', [2,3,4])
+        self.t('{a + 1 for a in [1,2,3]}', {2, 3, 4})
+        self.t('{a + 1: a - 1 for a in [1,2,3]}', {2: 0, 3: 1, 4: 2})
+
+    def test_setcomp(self):
+        self.t('{0 for a in [1,2,3]}', {0})
+        self.t('{a % 10 for a in [5,10,15,20]}', {0, 5})
+
+    def test_genexp(self):
+        self.t('list(a + 1 for a in [1,2,3])', [2, 3, 4])
 
     def test_with_self_reference(self):
         self.t('[a + a for a in [1,2,3]]', [2,4,6])
+        self.t('{a + a for a in [1,2,3]}', {2, 4, 6})
+        self.t('{a: a for a in [1,2,3]}', {1:1, 2:2, 3:3})
 
     def test_with_if(self):
         self.t('[a for a in [1,2,3,4,5] if a <= 3]', [1,2,3])
+        self.t('{a for a in [1,2,3,4,5] if a <= 3}', {1, 2, 3})
+        self.t('{a: a for a in [1,2,3,4,5] if a <= 3}', {1:1, 2:2, 3:3})
 
     def test_with_multiple_if(self):
-        self.t('[a for a in [1,2,3,4,5] if a <= 3 and a > 1 ]', [2,3])
+        self.t('[a for a in [1,2,3,4,5] if a <= 3 if a > 1 ]', [2,3])
+        self.t('{a for a in [1,2,3,4,5] if a <= 3 if a > 1 }', {2, 3})
+        self.t('{a:a for a in [1,2,3,4,5] if a <= 3 if a > 1 }', {2:2, 3:3})
 
     def test_attr_access_fails(self):
         with self.assertRaises(FeatureNotAvailable):
             self.t('[a.__class__ for a in [1,2,3]]', None)
+        with self.assertRaises(FeatureNotAvailable):
+            self.t('{a.__class__ for a in [1,2,3]}', None)
+        with self.assertRaises(FeatureNotAvailable):
+            self.t('{a.__class__: a for a in [1,2,3]}', None)
+        with self.assertRaises(FeatureNotAvailable):
+            self.t('{a: a.__class__ for a in [1,2,3]}', None)
 
     def test_unpack(self):
         self.t('[a+b for a,b in ((1,2),(3,4))]', [3, 7])
+        self.t('{a+b for a,b in ((1,2),(3,4))}', {3, 7})
+        self.t('{a: b for a,b in ((1,2),(3,4))}', {1:2, 3:4})
 
     def test_nested_unpack(self):
         self.t('[a+b+c for a, (b, c) in ((1,(1,1)),(3,(2,2)))]', [3, 7])
+        self.t('{a+b+c for a, (b, c) in ((1,(1,1)),(3,(2,2)))}', {3, 7})
+        self.t('{a:b+c for a, (b, c) in ((1,(1,1)),(3,(2,2)))}', {1:2, 3:4})
 
     def test_other_places(self):
         self.s.functions = {'sum': sum}
@@ -618,10 +643,18 @@ class TestComprehensions(DRYTest):
         self.s.functions = {'range': range}
         s = '[j for i in range(100) if i > 10 for j in range(i) if j < 20]'
         self.t(s, eval(s))
+        s = '{j for i in range(100) if i > 10 for j in range(i) if j < 20}'
+        self.t(s, eval(s))
+        s = '{j:i for i in range(100) if i > 10 for j in range(i) if j < 20}'
+        self.t(s, eval(s))
 
     def test_triple_generators(self):
         self.s.functions = {'range': range}
         s = '[(a,b,c) for a in range(4) for b in range(a) for c in range(b)]'
+        self.t(s, eval(s))
+        s = '{(a,b,c) for a in range(4) for b in range(a) for c in range(b)}'
+        self.t(s, eval(s))
+        s = '{a+b+c:(a,b,c) for a in range(4) for b in range(a) for c in range(b)}'
         self.t(s, eval(s))
 
     def test_too_long_generator(self):


### PR DESCRIPTION
Adds support for generator expressions as optimal iterables, set comprehensions, and dict comprehensions.

Renamed `_eval_comprehension()` to `_do_comprehension()`, an iterator that yields items of a comprehension as they are generated. Added `_eval_listcomp()`, `_eval_setcomp()`, `_eval_dictcomp()`, and `_eval_generatorexp()` as wrappers around `_do_comprehension()` to consume the items and return the correct datatype for a given comprehension.