### PR TITLE
Add EvalWithAssignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build
 dist
 MANIFEST
 .idea
+venv
 
 testfile.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ build
 dist
 MANIFEST
 .idea
-venv
+venv*
 
 testfile.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
     - "pypy3.5"
 install:
  - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
-    - "3.8"
     - "pypy3.5"
 install:
  - pip install nose

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -652,14 +652,15 @@ class EvalWithAssignments(SimpleEval):
         self.names[name.id] = value
 
 
+class _FinalValue:
+    def __init__(self, value):
+        self.value = value
+
+
 class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     """
     EvalWithAssignments with the ability to assign to compound types.
     """
-    class _FinalValue:
-        def __init__(self, value):
-            self.value = value
-
     def __init__(self, operators=None, functions=None, names=None):
         super(CompoundEvalWithAssignments, self).__init__(operators, functions, names)
 
@@ -673,7 +674,7 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
         })
 
         self.nodes.update({
-            self._FinalValue: lambda v: v.value
+            _FinalValue: lambda v: v.value
         })
 
     def _assign_subscript(self, name, value):
@@ -685,7 +686,7 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     def _assign_unpack(self, names, values):
         def do_assign(target, value):
             if not isinstance(target, (ast.Tuple, ast.List)):
-                self._assign(target, self._FinalValue(value=value))
+                self._assign(target, _FinalValue(value=value))
             else:
                 try:
                     value = list(iter(value))

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -665,6 +665,7 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     def _assign_subscript(self, name, value):
         container = self._eval(name.value)
         key = self._eval(name.slice)
+        value = self._eval(value)
         container[key] = value  # no further evaluation needed, if container is in names it will update
 
     def _assign_unpack(self, names, values):

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -656,6 +656,9 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     """
     EvalWithAssignments with the ability to assign to compound types.
     """
+    class _FinalValue:
+        def __init__(self, value):
+            self.value = value
 
     def __init__(self, operators=None, functions=None, names=None):
         super(CompoundEvalWithAssignments, self).__init__(operators, functions, names)
@@ -669,6 +672,10 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
             ast.Subscript: self._assign_subscript
         })
 
+        self.nodes.update({
+            self._FinalValue: lambda v: v.value
+        })
+
     def _assign_subscript(self, name, value):
         container = self._eval(name.value)
         key = self._eval(name.slice)
@@ -676,15 +683,9 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
         container[key] = value  # no further evaluation needed, if container is in names it will update
 
     def _assign_unpack(self, names, values):
-        new_names = {}
-
-        def recurse_targets(target, value):
-            """
-                Recursively (enter, (into, (nested, name), unpacking)) = \
-                             and, (assign, (values, to), each
-            """
-            if isinstance(target, ast.Name):
-                new_names[target.id] = value
+        def do_assign(target, value):
+            if not isinstance(target, (ast.Tuple, ast.List)):
+                self._assign(target, self._FinalValue(value=value))
             else:
                 try:
                     value = list(iter(value))
@@ -693,12 +694,10 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
                 if not len(target.elts) == len(value):
                     raise InvalidExpression("Unequal unpack: {} names, {} values".format(len(target.elts), len(value)))
                 for t, v in zip(target.elts, value):
-                    recurse_targets(t, v)
+                    do_assign(t, v)
 
         values = self._eval(values)
-
-        recurse_targets(names, values)
-        self.names.update(new_names)
+        do_assign(names, values)
 
 
 def simple_eval(expr, operators=None, functions=None, names=None):

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -603,6 +603,12 @@ class EvalWithAssignments(SimpleEval):
     def __init__(self, operators=None, functions=None, names=None):
         super(EvalWithAssignments, self).__init__(operators, functions, names)
 
+        self.nodes.update({
+            ast.Expr: self._eval_expr,
+            ast.Assign: self._eval_assign,
+            ast.AugAssign: self._eval_augassign
+        })
+
         self.assign_nodes = {
             ast.Name: self._assign_name,
         }
@@ -615,16 +621,17 @@ class EvalWithAssignments(SimpleEval):
 
         # and evaluate:
         expression = ast.parse(expr.strip()).body[0]
-        if isinstance(expression, ast.Expr):
-            return self._eval(expression.value)
-        elif isinstance(expression, ast.Assign):
-            for target in expression.targets:  # a = b = 1
-                self._assign(target, expression.value)
-        elif isinstance(expression, ast.AugAssign):  # a += 1
-            self._aug_assign(expression.target, expression.op, expression.value)
-        # TODO py 3.8 walrus op
-        else:
-            raise FeatureNotAvailable("Unknown ast body type: {}".format(type(expression).__name__))
+        return self._eval(expression)
+
+    def _eval_expr(self, node):
+        return self._eval(node.value)
+
+    def _eval_assign(self, node):
+        for target in node.targets:  # a = b = 1
+            self._assign(target, node.value)
+
+    def _eval_augassign(self, node):
+        self._aug_assign(node.target, node.op, node.value)
 
     def _assign(self, names, values):
         if not isinstance(self.names, dict):

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -652,15 +652,15 @@ class EvalWithAssignments(SimpleEval):
         self.names[name.id] = value
 
 
-class _FinalValue:
-    def __init__(self, value):
-        self.value = value
-
-
 class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     """
     EvalWithAssignments with the ability to assign to compound types.
     """
+
+    class _FinalValue(object):
+        def __init__(self, value):
+            self.value = value
+
     def __init__(self, operators=None, functions=None, names=None):
         super(CompoundEvalWithAssignments, self).__init__(operators, functions, names)
 
@@ -674,7 +674,7 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
         })
 
         self.nodes.update({
-            _FinalValue: lambda v: v.value
+            self._FinalValue: lambda v: v.value
         })
 
     def _assign_subscript(self, name, value):
@@ -686,7 +686,7 @@ class CompoundEvalWithAssignments(EvalWithCompoundTypes, EvalWithAssignments):
     def _assign_unpack(self, names, values):
         def do_assign(target, value):
             if not isinstance(target, (ast.Tuple, ast.List)):
-                self._assign(target, _FinalValue(value=value))
+                self._assign(target, self._FinalValue(value=value))
             else:
                 try:
                     value = list(iter(value))

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -791,6 +791,17 @@ class TestCompoundAssignments(DRYTest):
         self.s.eval('b["foo"] = "bletch"')
         self.t('b', {"foo": "bletch", 0: 0})
 
+    def test_compound_unpack(self):
+        self.s.names['x'] = (1, 2)
+        self.s.names['y'] = (1, (2, 3), 4)
+        self.s.eval('a = [1, 2, 3]')
+
+        self.s.eval('a[0], a[1] = (-1, -2)')
+        self.t('a', [-1, -2, 3])
+
+        self.s.eval('a[0], a[1], _ = y')
+        self.t('a', [1, (2, 3), 3])
+
     def test_assign_slice(self):
         self.s.eval('a = [1, 2, 3]')
         self.s.functions['range'] = range

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -791,6 +791,23 @@ class TestCompoundAssignments(DRYTest):
         self.s.eval('b["foo"] = "bletch"')
         self.t('b', {"foo": "bletch", 0: 0})
 
+    def test_assign_slice(self):
+        self.s.eval('a = [1, 2, 3]')
+        self.s.functions['range'] = range
+
+        self.s.eval('a[0:2] = range(2)')
+        self.t('a', [0, 1, 3])
+
+    def test_deep_assign(self):
+        self.s.eval('a = [[[0]]]')
+        self.s.eval('b = {0:{0:{0: 0}}}')
+
+        self.s.eval('a[0][0][0] = 1')
+        self.t('a', [[[1]]])
+
+        self.s.eval('b[0][0][0] = 1')
+        self.t('b', {0:{0:{0: 1}}})
+
 
 class TestNames(DRYTest):
     """ 'names', what other languages call variables... """

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -808,6 +808,17 @@ class TestCompoundAssignments(DRYTest):
         self.s.eval('b[0][0][0] = 1')
         self.t('b', {0:{0:{0: 1}}})
 
+    def test_references(self):
+        self.s.eval('a = [1, 2, 3]')
+        self.s.eval('b = a')
+
+        self.t('a is b', True)
+
+        self.s.eval('b[0] = 0')
+        self.t('a', [0, 2, 3])
+        self.t('b', [0, 2, 3])
+
+
 
 class TestNames(DRYTest):
     """ 'names', what other languages call variables... """


### PR DESCRIPTION
Adds EvalWithAssignments and CompoundEvalWithAssignments, extending SimpleEval and EvalWithCompoundTypes, respectively. 

These evaluators add the ability to assign names using normal Python syntax.