### PR TITLE
Add python3.8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build
 dist
 MANIFEST
 .idea
+venv
 
 testfile.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
     - "pypy3.5"
 install:
  - pip install nose


### PR DESCRIPTION
Fixes #61.

Python 3.8 [now uses `ast.Constant` instead of `ast.Num`, `ast.Str`, `ast.Bytes`, `ast.Ellipsis`, and `ast.NameConstant`](https://bugs.python.org/issue32892) - this PR adds a node handler for it.