### PR TITLE
Allow clearing the list of functions / operators / names

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -279,11 +279,11 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             Create the evaluator instance.  Set up valid operators (+,-, etc)
             functions (add, random, get_val, whatever) and names. """
 
-        if not operators:
+        if operators is None:
             operators = DEFAULT_OPERATORS.copy()
-        if not functions:
+        if functions is None:
             functions = DEFAULT_FUNCTIONS.copy()
-        if not names:
+        if names is None:
             names = DEFAULT_NAMES.copy()
 
         self.operators = operators

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -1080,5 +1080,14 @@ class TestDisallowedFunctions(DRYTest):
         simpleeval.DEFAULT_FUNCTIONS = DF.copy()
 
 
+class TestNoFunctions(DRYTest):
+    def test_no_functions(self):
+        self.s.eval('int(42)')
+        with self.assertRaises(FunctionNotDefined):
+            s = SimpleEval(functions={})
+            s.eval('int(42)')
+
+
+
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -15,7 +15,7 @@ import os
 import warnings
 from simpleeval import (
     SimpleEval, EvalWithCompoundTypes, FeatureNotAvailable, FunctionNotDefined, NameNotDefined,
-    InvalidExpression, AttributeDoesNotExist, simple_eval
+    OperatorNotDefined, InvalidExpression, AttributeDoesNotExist, simple_eval
 )
 
 
@@ -981,7 +981,7 @@ class TestUnusualComparisons(DRYTest):
         b = Blah()
         self.s.names = {'b': b}
         # This should not crash:
-        e = eval('b > 2', self.s.names)
+        e = eval('b > 2', self.s.names)  
 
         self.t('b > 2', BinaryExpression('GT'))
         self.t('1 < 5 > b', BinaryExpression('LT'))
@@ -1080,12 +1080,25 @@ class TestDisallowedFunctions(DRYTest):
         simpleeval.DEFAULT_FUNCTIONS = DF.copy()
 
 
-class TestNoFunctions(DRYTest):
+class TestNoEntries(DRYTest):
     def test_no_functions(self):
         self.s.eval('int(42)')
         with self.assertRaises(FunctionNotDefined):
             s = SimpleEval(functions={})
             s.eval('int(42)')
+
+    def test_no_names(self):
+        # does not work, AST interprets built-ins directly
+        self.s.eval('True')
+        # with self.assertRaises(NameNotDefined):
+        s = SimpleEval(names={})
+        s.eval('True')
+
+    def test_no_operators(self):
+        self.s.eval('1+2')
+        with self.assertRaises(OperatorNotDefined):
+            s = SimpleEval(operators={})
+            s.eval('1+2')
 
 
 

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -1088,11 +1088,15 @@ class TestNoEntries(DRYTest):
             s.eval('int(42)')
 
     def test_no_names(self):
-        # does not work, AST interprets built-ins directly
+        # does not work on current Py3, True et al. are keywords now
         self.s.eval('True')
         # with self.assertRaises(NameNotDefined):
         s = SimpleEval(names={})
-        s.eval('True')
+        if sys.version_info < (3,):
+            with self.assertRaises(NameNotDefined):
+                s.eval('True')
+        else:
+            s.eval('True')
 
     def test_no_operators(self):
         self.s.eval('1+2')


### PR DESCRIPTION
If you want to disallow function calls entirely, using an empty dict now works. Same for operators and names.

NB: Python3 doesn't let you remove True/False/None because these are now the equivalent of keywords, thus I disabled that test. Oh well.