### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 dist: xenial
+arch:
+  - amd64
+  - ppc64le
 python:
     - "2.7"
     - "3.4"
@@ -8,6 +11,12 @@ python:
     - "3.7"
     - "3.8"
     - "pypy3.5"
+matrix:
+  exclude:
+     - python:  "2.7"
+       arch: ppc64le
+     - python: "pypy3.5"
+       arch: ppc64le
 install:
  - pip install nose
  - pip install coveralls


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/simpleeval/builds/208658968 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!