### PR TITLE
Remove import, functions, keywords, subscripts and attribute access.  Everything should be explicitly added as extras.

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -296,7 +296,6 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.Expr: self._eval_expr,
             ast.Assign: self._eval_assign,
             ast.AugAssign: self._eval_aug_assign,
-            ast.Import: self._eval_import,
             ast.Num: self._eval_num,
             ast.Str: self._eval_str,
             ast.Name: self._eval_name,
@@ -305,10 +304,6 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.BoolOp: self._eval_boolop,
             ast.Compare: self._eval_compare,
             ast.IfExp: self._eval_ifexp,
-            ast.Call: self._eval_call,
-            ast.keyword: self._eval_keyword,
-            ast.Subscript: self._eval_subscript,
-            ast.Attribute: self._eval_attribute,
             ast.Index: self._eval_index,
             ast.Slice: self._eval_slice,
         }


### PR DESCRIPTION
This lib claims:

> Simple **Safe** Sandboxed Extensible Expression Evaluator

So it must be secure by default. But it is not possible to make it secure in presence of such dangerous functions. So this commit gets rid of them.

https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html claims

>The problem with all of these attempts to protect eval() is that they are blacklists. They explicitly remove things that could be dangerous. That is a losing battle because if there’s just one item left off the list, you can attack the system.

and I completely agree with it.

If a user needs to allow these AST nodes in an insecure way (which defeats purpose of this lib), he can do it explicitly. The functions are still in place, all he needs is to subclass the class and add them to the dict.

If a user needs to allow them in a more secure way, he will implement them himself knowing the specifics of the code he calls and allowing only the API he is sure must be called by the code and in a more secure way.