### PR TITLE
disable redundant use_2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     download_url='https://github.com/danthedeckie/simpleeval/tarball/' + __version__,
     keywords=['eval', 'simple', 'expression', 'parse', 'ast'],
     test_suite='test_simpleeval',
-    use_2to3=True,
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
the source code of this project is already py2/py3 compatible and so use_2to3 is redundant