### PR TITLE
fix installation with setuptools>=58

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ arch:
   - amd64
   - ppc64le
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
     - "pypy3.5"
 matrix:
   exclude:
-     - python:  "2.7"
-       arch: ppc64le
      - python: "pypy3.5"
        arch: ppc64le
 install:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.9.10'
+__version__ = '0.9.11'
 
 setup(
     name='simpleeval',
@@ -15,7 +15,6 @@ setup(
     download_url='https://github.com/danthedeckie/simpleeval/tarball/' + __version__,
     keywords=['eval', 'simple', 'expression', 'parse', 'ast'],
     test_suite='test_simpleeval',
-    use_2to3=True,
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: MIT License',

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -97,8 +97,6 @@ import sys
 import warnings
 from random import random
 
-PYTHON3 = sys.version_info[0] == 3
-
 ########################################
 # Module wide 'globals'
 
@@ -124,8 +122,7 @@ if hasattr(__builtins__, 'help') or \
     DISALLOW_FUNCTIONS.add(help)
 
 
-if PYTHON3:
-    exec('DISALLOW_FUNCTIONS.add(exec)') # exec is not a function in Python2...
+exec('DISALLOW_FUNCTIONS.add(exec)')
 
 
 ########################################
@@ -255,7 +252,7 @@ DEFAULT_OPERATORS = {ast.Add: safe_add, ast.Sub: op.sub, ast.Mult: safe_mult,
 
 DEFAULT_FUNCTIONS = {"rand": random, "randint": random_int,
                      "int": int, "float": float,
-                     "str": str if PYTHON3 else unicode}
+                     "str": str}
 
 DEFAULT_NAMES = {"True": True, "False": False, "None": None}
 

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -1048,8 +1048,7 @@ class TestShortCircuiting(DRYTest):
 class TestDisallowedFunctions(DRYTest):
     def test_functions_are_disallowed_at_init(self):
         DISALLOWED = [type, isinstance, eval, getattr, setattr, help, repr, compile, open]
-        if simpleeval.PYTHON3:
-            exec('DISALLOWED.append(exec)') # exec is not a function in Python2...
+        exec('DISALLOWED.append(exec)') # exec is not a function in Python2...
 
         for f in simpleeval.DISALLOW_FUNCTIONS:
             assert f in DISALLOWED
@@ -1061,8 +1060,7 @@ class TestDisallowedFunctions(DRYTest):
     def test_functions_are_disallowed_in_expressions(self):
         DISALLOWED = [type, isinstance, eval, getattr, setattr, help, repr, compile, open]
 
-        if simpleeval.PYTHON3:
-            exec('DISALLOWED.append(exec)') # exec is not a function in Python2...
+        exec('DISALLOWED.append(exec)') # exec is not a function in Python2...
 
         for f in simpleeval.DISALLOW_FUNCTIONS:
             assert f in DISALLOWED


### PR DESCRIPTION
setuptools introduced a breaking changes which removes support for `use_2to3` in the setup config. This makes it hard to install simpleeval on systems with the new version without performing multiple steps:

1. Downgrade setuptools
2. Install simpleeval

Unfortunately those can't be performed in a single step since pip evaluates the setup.py file during the download process (which happens before any other packages have been installed / updated. That means that even if you have `setuptools<58` in your pip requirements files you still own't be able to install simpleval (unless you already have a cached copy locally).

In addition to removing that flag from setup.py this PR also removes support for python 2.7, 3.4 and 3.5 which are all past EOL.