### PR TITLE
Handle empty string while evaluating expression

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -382,11 +382,14 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         names previously set up."""
 
         # set a copy of the expression aside, so we can give nice errors...
-
         self.expr = expr
 
-        # and evaluate:
-        return self._eval(ast.parse(expr.strip()).body[0])
+        parsed = ast.parse(expr.strip())
+        if len(parsed.body) > 0:
+            # evaluate if not empty
+            return self._eval(parsed.body[0])
+        else:
+            raise InvalidExpression("Sorry, cannot evaluate empty string")
 
     def _eval(self, node):
         """The internal evaluator used on each node in the parsed tree."""

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -189,6 +189,10 @@ class TestBasic(DRYTest):
         with self.assertRaises(FeatureNotAvailable):
             self.t("{22}", False)
 
+    def test_empty_string_not_allowed(self):
+        with self.assertRaises(InvalidExpression):
+            self.t("", False)
+
 
 class TestFunctions(DRYTest):
     """Functions for expressions to play with"""


### PR DESCRIPTION
# Description
_What is this PR doing?_
#67
When giving simpleeval an empty string it raises this error:
```
Traceback (most recent call last):
  File "simpleeval.py", line 613, in simple_eval
    return s.eval(expr)
  File "simpleeval.py", line 334, in eval
    return self._eval(parsed.body[0].value)
IndexError: list index out of range
```
This change raises a proper `InvalidExpression` error

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
- [ ] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)
