### PR TITLE
Separate `parse` method and improve...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,21 @@ cases):
 
     # and so on...
 
+One useful feature of using the ``SimpleEval`` object is that you can parse an expression
+once, and then evaluate it mulitple times using different ``names``:
+
+.. code-block:: python
+    # Set up & Cache the parse tree:
+    expression = "foo + bar"
+    parsed = s.parse(expression)
+
+    # evaluate the expression multiple times:
+    for names in [{"foo": 1, "bar": 10}, {"foo": 100, "bar": 42}]:
+        s.names = names
+        print(s.eval(expression, previously_parsed=parsed))
+
+for instance.  This may help with performance.
+
 You can assign / edit the various options of the ``SimpleEval`` object if you
 want to.  Either assign them during creation (like the ``simple_eval``
 function)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black==23.1.0
 isort==5.10.1
 pylint==2.12.2
 mypy==0.931

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -391,17 +391,14 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
 
         parsed = ast.parse(expr.strip())
 
-        body_len = len(parsed.body)
-        if body_len > 0:
-            if body_len > 1:
-                warnings.warn(
-                    "'{}' contains multiple expressions. Only the first will be used.".format(
-                        expr
-                    ),
-                    MultipleExpressions,
-                )
-            return parsed.body[0]
-        raise InvalidExpression("Sorry, cannot evaluate empty string")
+        if not parsed.body:
+            raise InvalidExpression("Sorry, cannot evaluate empty string")
+        if len(parsed.body) > 1:
+            warnings.warn(
+                "'{}' contains multiple expressions. Only the first will be used.".format(expr),
+                MultipleExpressions,
+            )
+        return parsed.body[0]
 
     def eval(self, expr, previously_parsed=None):
         """evaluate an expresssion, using the operators, functions and

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -226,7 +226,7 @@ def safe_power(a, b):  # pylint: disable=invalid-name
 
     if abs(a) > MAX_POWER or abs(b) > MAX_POWER:
         raise NumberTooHigh("Sorry! I don't want to evaluate {0} ** {1}".format(a, b))
-    return a ** b
+    return a**b
 
 
 def safe_mult(a, b):  # pylint: disable=invalid-name

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -372,7 +372,7 @@ class TestTryingToBreakOut(DRYTest):
         """exponent operations can take a long time."""
         old_max = simpleeval.MAX_POWER
 
-        self.t("9**9**5", 9 ** 9 ** 5)
+        self.t("9**9**5", 9**9**5)
 
         with self.assertRaises(simpleeval.NumberTooHigh):
             self.t("9**9**8", 0)


### PR DESCRIPTION
# Description
- Split 'parse' stage to separate method
- allow previously_parsed in 'eval'
- Warn if multiple expressions.

This allows AST caching as in #85, #60 etc - but the caching should be done outside of the evaluator.

The warning about multiple expressions is something I've wanted for a while.

# TODO
- add to docs.

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
