### PR TITLE
pyproject.toml: remove build as a build-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "build"]
+requires = ["setuptools>=30.3.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
pypa/build is one possible build tool, but not the only build tool.  Forcing build to be present as a build dependency is meaningless: either the user is using build so obviously have build, or are using something else so having build is irrelevant.

No need to add me to contributors, this is trivial.