### PR TITLE
Drop CI testing of Python 2.7 and 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,9 @@
+CHANGELOG
+#########
+
+
+Unreleased changes
+==================
+
+*   Drop CI testing for Python 2.7 and Python 3.6,
+    which have both reached end of life status.


### PR DESCRIPTION
# Description
Drop CI testing for Python 2.7 and Python 3.6, which have both reached end-of-life status.

In addition, this adds a CHANGELOG, which is critical file to have for other developers' understanding of the project.

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)

I don't want my name added to the contributors list for such a small change.

Note that the lint check is failing in CI due to existing failures in the dependencies. I'll try to fix this in a separate PR.