### PR TITLE
Address `ast` deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
-        - '3.13-dev'
+        - '3.13'
         - 'pypy-3.8'
         - 'pypy-3.9'
         - 'pypy-3.10'
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Generate Report
         run: |
           pip install coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,22 @@ jobs:
           make lint
   run:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.python == '2.7' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev', 'pypy-3.8']
+        python:
+        - '2.7'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13-dev'
+        - 'pypy-3.8'
+        - 'pypy-3.9'
+        - 'pypy-3.10'
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -57,6 +57,7 @@ Contributors:
 - bozokopic (Bozo Kopic) Memory leak fix
 - daxamin (Dax Amin) Better error for attempting to eval empty string
 - smurfix (Matthias Urlichs) Allow clearing functions / operators / etc completely
+- edgarrmondragon (Edgar Ramírez-Mondragón) Address Python 3.12+ deprecation warnings
 
 -------------------------------------
 Basic Usage:
@@ -359,8 +360,6 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.Assign: self._eval_assign,
             ast.AugAssign: self._eval_aug_assign,
             ast.Import: self._eval_import,
-            ast.Num: self._eval_num,
-            ast.Str: self._eval_str,
             ast.Name: self._eval_name,
             ast.UnaryOp: self._eval_unaryop,
             ast.BinOp: self._eval_binop,
@@ -389,6 +388,14 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         # py3.8 uses ast.Constant instead of ast.Num, ast.Str, ast.NameConstant
         if hasattr(ast, "Constant"):
             self.nodes[ast.Constant] = self._eval_constant
+
+        # py3.12 deprecated ast.Num, ast.Str, ast.NameConstant
+        # https://docs.python.org/3.12/whatsnew/3.12.html#deprecated
+        if hasattr(ast, "Num"):
+            self.nodes[ast.Num] = self._eval_num
+
+        if hasattr(ast, "Str"):
+            self.nodes[ast.Str] = self._eval_str
 
         # Defaults:
 


### PR DESCRIPTION
# Description

* Adapted code for future removal of `ast.Num`, `ast.Str` and `ast.NameConstant`
* Added tests for stable Python 3.12, alpha 3.13, as well as pypy 3.9 and 3.10
* Added `continue-on-error: true` for 2.7 cause it's no longer available with actions/setup-python

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [ ] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)
