### PR TITLE
Catch warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	python test_simpleeval.py
+	python -Werror test_simpleeval.py
 
 autotest:
 	find . -name \*.py -not -path .\/.v\* | entr make test

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -360,8 +360,6 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.Assign: self._eval_assign,
             ast.AugAssign: self._eval_aug_assign,
             ast.Import: self._eval_import,
-            ast.Num: self._eval_num,
-            ast.Str: self._eval_str,
             ast.Name: self._eval_name,
             ast.UnaryOp: self._eval_unaryop,
             ast.BinOp: self._eval_binop,
@@ -376,20 +374,28 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             ast.Slice: self._eval_slice,
         }
 
-        # py3k stuff:
-        if hasattr(ast, "NameConstant"):
-            self.nodes[ast.NameConstant] = self._eval_constant
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            # py3k stuff:
+            if hasattr(ast, "NameConstant"):
+                self.nodes[ast.NameConstant] = self._eval_constant
 
-        # py3.6, f-strings
-        if hasattr(ast, "JoinedStr"):
-            self.nodes[ast.JoinedStr] = self._eval_joinedstr  # f-string
-            self.nodes[
-                ast.FormattedValue
-            ] = self._eval_formattedvalue  # formatted value in f-string
+            # py3.6, f-strings
+            if hasattr(ast, "JoinedStr"):
+                self.nodes[ast.JoinedStr] = self._eval_joinedstr  # f-string
+                self.nodes[
+                    ast.FormattedValue
+                ] = self._eval_formattedvalue  # formatted value in f-string
 
-        # py3.8 uses ast.Constant instead of ast.Num, ast.Str, ast.NameConstant
-        if hasattr(ast, "Constant"):
-            self.nodes[ast.Constant] = self._eval_constant
+            # py3.8 uses ast.Constant instead of ast.Num, ast.Str, ast.NameConstant
+            if hasattr(ast, "Constant"):
+                self.nodes[ast.Constant] = self._eval_constant
+
+            # py3.14 removal
+            if hasattr(ast, 'Num'):
+                self.nodes[ast.Num] = self._eval_num
+            if hasattr(ast, 'Str'):
+                self.nodes[ast.Str] = self._eval_str
 
         # Defaults:
 

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -209,6 +209,7 @@ class TestEvaluator(DRYTest):
     def test_only_evalutate_first_statement(self):
         # it only evaluates the first statement:
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("11; x = 21; x + x", 11)
         self.assertIsInstance(ws[0].message, simpleeval.MultipleExpressions)
 
@@ -795,6 +796,7 @@ class TestNames(DRYTest):
         # or if you attempt to assign an unknown name to another
         with self.assertRaises(NameNotDefined):
             with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter('always')
                 self.t("s += a", 21)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -820,6 +822,7 @@ class TestNames(DRYTest):
 
         # however, you can't assign to those names:
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("a = 200", 200)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -830,6 +833,7 @@ class TestNames(DRYTest):
         self.s.names["b"] = [0]
 
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("b[0] = 11", 11)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -853,6 +857,7 @@ class TestNames(DRYTest):
         # you still can't assign though:
 
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("c['b'] = 99", 99)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -863,6 +868,7 @@ class TestNames(DRYTest):
         self.s.names["c"]["c"] = {"c": 11}
 
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("c['c']['c'] = 21", 21)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -878,6 +884,7 @@ class TestNames(DRYTest):
         self.t("a.b.c*2", 84)
 
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("a.b.c = 11", 11)
         self.assertIsInstance(ws[0].message, simpleeval.AssignmentAttempted)
 
@@ -885,6 +892,7 @@ class TestNames(DRYTest):
 
         # TODO: Wat?
         with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
             self.t("a.d = 11", 11)
 
         with self.assertRaises(KeyError):


### PR DESCRIPTION
# Description
It prevents to raise warnings when using simpleeval correctly.
This is useful when you want to run code that uses simepleeval with `-Werror` .

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)
