### PR TITLE
Optional type-method/attr access safety

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -107,6 +107,7 @@ import operator as op
 import sys
 import warnings
 from random import random
+from typing import Type, Dict, Set, Union
 
 ########################################
 # Module wide 'globals'
@@ -144,7 +145,7 @@ if hasattr(__builtins__, "help") or (
 
 # Opt-in type safety experiment. Will be opt-out in 2.x
 
-BASIC_ALLOWED_ATTRS = {
+BASIC_ALLOWED_ATTRS: Dict[Union[Type, None], Set] = {
     int: {
         "as_integer_ratio",
         "bit_length",

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -225,7 +225,7 @@ BASIC_ALLOWED_ATTRS = {
         "real",
         "to_bytes",
     },
-    None: {},
+    None: set(),
     dict: {
         "clear",
         "copy",

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -142,9 +142,145 @@ if hasattr(__builtins__, "help") or (
     # PyInstaller environment doesn't include this module.
     DISALLOW_FUNCTIONS.add(help)
 
+# Opt-in type safety experiment. Will be opt-out in 2.x
+
+BASIC_ALLOWED_ATTRS = {
+    int: {
+        "as_integer_ratio",
+        "bit_length",
+        "conjugate",
+        "denominator",
+        "from_bytes",
+        "imag",
+        "numerator",
+        "real",
+        "to_bytes",
+    },
+    float: {
+        "as_integer_ratio",
+        "conjugate",
+        "fromhex",
+        "hex",
+        "imag",
+        "is_integer",
+        "real",
+    },
+    str: {
+        "capitalize",
+        "casefold",
+        "center",
+        "count",
+        "encode",
+        "endswith",
+        "expandtabs",
+        "find",
+        "format",
+        "format_map",
+        "index",
+        "isalnum",
+        "isalpha",
+        "isascii",
+        "isdecimal",
+        "isdigit",
+        "isidentifier",
+        "islower",
+        "isnumeric",
+        "isprintable",
+        "isspace",
+        "istitle",
+        "isupper",
+        "join",
+        "ljust",
+        "lower",
+        "lstrip",
+        "maketrans",
+        "partition",
+        "removeprefix",
+        "removesuffix",
+        "replace",
+        "rfind",
+        "rindex",
+        "rjust",
+        "rpartition",
+        "rsplit",
+        "rstrip",
+        "split",
+        "splitlines",
+        "startswith",
+        "strip",
+        "swapcase",
+        "title",
+        "translate",
+        "upper",
+        "zfill",
+    },
+    bool: {
+        "as_integer_ratio",
+        "bit_length",
+        "conjugate",
+        "denominator",
+        "from_bytes",
+        "imag",
+        "numerator",
+        "real",
+        "to_bytes",
+    },
+    None: {},
+    dict: {
+        "clear",
+        "copy",
+        "fromkeys",
+        "get",
+        "items",
+        "keys",
+        "pop",
+        "popitem",
+        "setdefault",
+        "update",
+        "values",
+    },
+    list: {
+        "pop",
+        "append",
+        "index",
+        "reverse",
+        "count",
+        "sort",
+        "copy",
+        "extend",
+        "clear",
+        "insert",
+        "remove",
+    },
+    set: {
+        "pop",
+        "intersection_update",
+        "intersection",
+        "issubset",
+        "symmetric_difference_update",
+        "discard",
+        "isdisjoint",
+        "difference_update",
+        "issuperset",
+        "add",
+        "copy",
+        "union",
+        "clear",
+        "update",
+        "symmetric_difference",
+        "difference",
+        "remove",
+    },
+    tuple: {"index", "count"},
+}
+
 
 ########################################
 # Exceptions:
+
+
+class TypeNotSpecified(Exception):
+    pass
 
 
 class InvalidExpression(Exception):
@@ -344,7 +480,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
 
     expr = ""
 
-    def __init__(self, operators=None, functions=None, names=None):
+    def __init__(self, operators=None, functions=None, names=None, allowed_attrs=None):
         """
         Create the evaluator instance.  Set up valid operators (+,-, etc)
         functions (add, random, get_val, whatever) and names."""
@@ -359,6 +495,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         self.operators = operators
         self.functions = functions
         self.names = names
+        self.allowed_attrs = allowed_attrs
 
         self.nodes = {
             ast.Expr: self._eval_expr,
@@ -587,6 +724,8 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         return container[key]
 
     def _eval_attribute(self, node):
+        # DISALLOW_PREFIXES & DISALLOW_METHODS are global, there's never any access to
+        # attrs with these names, so we can bail early:
         for prefix in DISALLOW_PREFIXES:
             if node.attr.startswith(prefix):
                 raise FeatureNotAvailable(
@@ -598,8 +737,26 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             raise FeatureNotAvailable(
                 "Sorry, this method is not available. " "({0})".format(node.attr)
             )
-        # eval node
+
+        # Evaluate "node" - the thing that we're trying to access an attr of first:
         node_evaluated = self._eval(node.value)
+
+        # If we've opted in to the 'allowed_attrs' checking per type, then since we now
+        # know what kind of node we've got, we can check if we're permitted to access this
+        # attr name on this node:
+        if self.allowed_attrs is not None:
+            type_to_check = type(node_evaluated)
+
+            allowed_attrs = self.allowed_attrs.get(type_to_check, TypeNotSpecified)
+            if allowed_attrs == TypeNotSpecified:
+                raise FeatureNotAvailable(
+                    f"Sorry, attribute access not allowed on '{type_to_check}'"
+                    f" (attempted to access `.{node.attr}`)"
+                )
+            if node.attr not in allowed_attrs:
+                raise FeatureNotAvailable(
+                    f"Sorry, '.{node.attr}' access not allowed on '{type_to_check}'"
+                )
 
         # Maybe the base object is an actual object, not just a dict
         try:
@@ -762,7 +919,12 @@ class EvalWithCompoundTypes(SimpleEval):
         return to_return
 
 
-def simple_eval(expr, operators=None, functions=None, names=None):
+def simple_eval(expr, operators=None, functions=None, names=None, allowed_attrs=None):
     """Simply evaluate an expression"""
-    s = SimpleEval(operators=operators, functions=functions, names=names)
+    s = SimpleEval(
+        operators=operators,
+        functions=functions,
+        names=names,
+        allowed_attrs=allowed_attrs,
+    )
     return s.eval(expr)

--- a/simpleeval.py
+++ b/simpleeval.py
@@ -813,8 +813,8 @@ class EvalWithCompoundTypes(SimpleEval):
 
     _max_count = 0
 
-    def __init__(self, operators=None, functions=None, names=None):
-        super(EvalWithCompoundTypes, self).__init__(operators, functions, names)
+    def __init__(self, operators=None, functions=None, names=None, allowed_attrs=None):
+        super(EvalWithCompoundTypes, self).__init__(operators, functions, names, allowed_attrs)
 
         self.functions.update(list=list, tuple=tuple, dict=dict, set=set)
 

--- a/test_simpleeval.py
+++ b/test_simpleeval.py
@@ -19,6 +19,7 @@ import warnings
 
 import simpleeval
 from simpleeval import (
+    BASIC_ALLOWED_ATTRS,
     AttributeDoesNotExist,
     EvalWithCompoundTypes,
     FeatureNotAvailable,
@@ -1349,6 +1350,78 @@ class TestNoEntries(DRYTest):
 
         with self.assertRaises(OperatorNotDefined):
             s.eval("~ 2")
+
+
+class TestAllowedAttributes(DRYTest):
+    def setUp(self):
+        self.saved_disallow_methods = simpleeval.DISALLOW_METHODS
+        simpleeval.DISALLOW_METHODS = []
+        super().setUp()
+
+    def tearDown(self) -> None:
+        simpleeval.DISALLOW_METHODS = self.saved_disallow_methods
+        return super().tearDown()
+
+    def test_allowed_attrs_(self):
+        self.s.allowed_attrs = BASIC_ALLOWED_ATTRS
+        self.t("5 + 5", 10)
+        self.t('"   hello  ".strip()', "hello")
+
+    def test_allowed_extra_attr(self):
+        class Foo:
+            def bar(self):
+                return 42
+
+        assert Foo().bar() == 42
+
+        extended_attrs = BASIC_ALLOWED_ATTRS.copy()
+        extended_attrs[Foo] = {"bar"}
+
+        simple_eval("foo.bar()", names={"foo": Foo()}, allowed_attrs=extended_attrs)
+
+    def test_disallowed_extra_attr(self):
+        class Foo:
+            bar = 42
+            hidden = 100
+
+        assert Foo().bar == 42
+
+        extended_attrs = BASIC_ALLOWED_ATTRS.copy()
+        extended_attrs[Foo] = {"bar"}
+
+        self.assertEqual(
+            simple_eval("foo.bar", names={"foo": Foo()}, allowed_attrs=extended_attrs), 42
+        )
+        with self.assertRaisesRegex(FeatureNotAvailable, r".*'\.hidden' access not allowed.*"):
+            self.assertEqual(
+                simple_eval("foo.hidden", names={"foo": Foo()}, allowed_attrs=extended_attrs), 42
+            )
+
+    def test_disallowed_types(self):
+        class Foo:
+            bar = 42
+
+        assert Foo().bar == 42
+
+        with self.assertRaises(FeatureNotAvailable):
+            simple_eval("foo.bar", names={"foo": Foo()}, allowed_attrs=BASIC_ALLOWED_ATTRS)
+
+    def test_breakout_via_generator(self):
+        # Thanks decorator-factory
+        class Foo:
+            def bar(self):
+                yield "Hello, world!"
+
+        # Test the generator does work - also adds the `yield` to codecov...
+        assert list(Foo().bar()) == ["Hello, world!"]
+
+        evil = "foo.bar().gi_frame.f_globals['__builtins__'].exec('raise RuntimeError(\"Oh no\")')"
+
+        extended_attrs = BASIC_ALLOWED_ATTRS.copy()
+        extended_attrs[Foo] = {"bar"}
+
+        with self.assertRaisesRegex(FeatureNotAvailable, r".*attempted to access `\.gi_frame`.*"):
+            simple_eval(evil, names={"foo": Foo()}, allowed_attrs=extended_attrs)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
# Description
Basic opt-in type checking for allowed methods rather than the current 'disallow-methods' system.

In short - it's easier to be sure we're safe if we explicitly list functions/attrs/methods that are safe rather than try to catch all the possible unsafe methods/accesses.

This would be the default in 2.x, but opt-in for 1.x to maintain backwards compatibility.

See the README in the changed files for how this should work.

(For 2.x, we should see if there's a good way to make the defaults even more stripped back - and have every feature opt-in - that would be cool?)


# References:

- #81 
- #125 

## TODO

- [x] More tests
- [ ] Check it works for dictionary access etc.
- [ ] Are there any other basic types we should allow by default?
- [x] README / docs update about this feature.