### PR TITLE
Bump version with pip runtime requirement removed.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpleeval"
-version = "1.0.1"
+version = "1.0.2"
 requires-python = ">=3.9"
 readme = "README.rst"
 description = "A simple, safe single expression evaluator library."


### PR DESCRIPTION
# Description
Bumps the version number for a new release with #156 - `pip` version requirement removed.