### PR TITLE
Version bump for 1.0.3 release (supporting python3.14...)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simpleeval"
-version = "1.0.2"
+version = "1.0.3"
 requires-python = ">=3.9"
 readme = "README.rst"
 description = "A simple, safe single expression evaluator library."


### PR DESCRIPTION
# Description
Bumps the version number for 1.0.3 release.

1.0.3 includes:

- Spelling fixes
- 3.14 support (fix `getattr` missing default)