### PR TITLE
perf: check disallowed items at name-resolution boundary, not every AST node

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -680,9 +680,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
                 "Sorry, {0} is not available in this evaluator".format(type(node).__name__)
             )
 
-        result = handler(node)
-        self._check_disallowed_items(result)
-        return result
+        return handler(node)
 
     def _eval_expr(self, node):
         return self._eval(node.value)
@@ -797,14 +795,18 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             # that there is a true expression assigning to none
             # (the compiler rejects it, so you can't even
             # pass that to ast.parse)
-            return self.names[node.id]
+            val = self.names[node.id]
+            self._check_disallowed_items(val)
+            return val
 
         except (TypeError, KeyError):
             pass
 
         if callable(self.names):
             try:
-                return self.names(node)
+                val = self.names(node)
+                self._check_disallowed_items(val)
+                return val
             except NameNotDefined:
                 pass
         elif not hasattr(self.names, "__getitem__"):
@@ -815,7 +817,9 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
             )
 
         if node.id in self.functions:
-            return self.functions[node.id]
+            val = self.functions[node.id]
+            self._check_disallowed_items(val)
+            return val
 
         raise NameNotDefined(node.id, self.expr)
 

--- a/tests/test_check_boundary.py
+++ b/tests/test_check_boundary.py
@@ -1,0 +1,55 @@
+"""Tests verifying that _check_disallowed_items fires at the trust boundary
+(name resolution) and not on every intermediate AST node.
+
+Performance is checked by validating that the number of ``_check_disallowed_items`` calls equals the number
+of distinct name lookups, not the total number of AST nodes evaluated.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from simpleeval import SimpleEval
+
+
+class TestCheckCalledAtBoundary(unittest.TestCase):
+    """_check_disallowed_items should be called once per name lookup, not once
+    per AST node."""
+
+    def _count_checks(self, s, expr):
+        count = 0
+        original = s._check_disallowed_items.__func__
+
+        def counting(self_inner, item):
+            nonlocal count
+            count += 1
+            return original(self_inner, item)
+
+        with patch.object(type(s), "_check_disallowed_items", counting):
+            s.eval(expr)
+
+        return count
+
+    def test_simple_expression_calls_per_name(self):
+        """A simple expression with two distinct names should cause exactly
+        two checks (one per name lookup), regardless of how many AST nodes
+        the expression contains."""
+        s = SimpleEval(names={"a": 1, "b": 2})
+        # 'a + b * (a - b)' has 4 Name nodes (a, b, a, b). The number of checks
+        # should equal the number of Name node evaluations (4), NOT the total
+        # number of AST nodes (7+).
+        checks = self._count_checks(s, "a + b * (a - b)")
+        # Each *occurrence* of a name in the expression triggers one lookup:
+        self.assertEqual(checks, 4)  # Instead of 8
+
+    def test_complex_expression_node_count_independence(self):
+        """Wrap a simple lookup in deeply nested arithmetic - the check count
+        must not grow with nesting depth."""
+        s = SimpleEval(names={"x": 5})
+
+        shallow_checks = self._count_checks(s, "x + 1")
+        deep_checks = self._count_checks(s, "x + 1 + 1 + 1 + 1 + 1")
+
+        # Both have exactly one Name node ('x'), so both should trigger
+        # exactly one check:
+        self.assertEqual(shallow_checks, 1)  # Instead of 4
+        self.assertEqual(deep_checks, 1)  # Instead of 12

--- a/tests/test_module_wrapper.py
+++ b/tests/test_module_wrapper.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from simpleeval import (
+    EvalWithCompoundTypes,
     FeatureNotAvailable,
     ModuleWrapper,
     SimpleEval,
@@ -171,3 +172,31 @@ class TestModuleWrapperAccess(DRYTest):
 
         result = s.eval("data['value']")
         self.assertEqual(result, 42)
+
+    def test_wrapped_module_with_compound_types(self):
+        """ModuleWrapper can be used with EvalWithCompoundTypes."""
+        import datetime
+
+        s = EvalWithCompoundTypes(names={"dt": ModuleWrapper(datetime)})
+
+        result = s.eval("tuple(dt.date(2024, 1, 1).timetuple())")
+        self.assertEqual(result, (2024, 1, 1, 0, 0, 0, 0, 1, -1))
+
+
+class TestModuleNeedsWrapping(unittest.TestCase):
+    """Modules must still be blocked even when supplied via nested values."""
+
+    def test_unwrapped_module(self):
+        s = SimpleEval(names={"mymod": os})
+        with self.assertRaisesRegex(FeatureNotAvailable, "Sorry, modules are not allowed"):
+            s.eval("mymod.name")
+
+    def test_unwrapped_module_in_list_is_blocked(self):
+        s = SimpleEval(names={"items": [os, 1]})
+        with self.assertRaisesRegex(FeatureNotAvailable, "Sorry, modules are not allowed"):
+            s.eval("items")
+
+    def test_unwrapped_module_in_dict_value_is_blocked(self):
+        s = SimpleEval(names={"d": {"m": os}})
+        with self.assertRaisesRegex(FeatureNotAvailable, "Sorry, modules are not allowed"):
+            s.eval("d")


### PR DESCRIPTION
# Description
_What is this PR doing?_

Reduces the number of `_check_disallowed_items` calls by calling it once per name lookup instead of for _every_ AST node.

Only `ast.Name` nodes are relevant because they are supplied by the caller, and no other `ast.Name` nodes are available in the simpleeval sandbox during evaluation (AFAICT!).

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)

<details><summary>Additional Context by Claude</summary>
<p>

simpleeval 1.0.5 introduced `_check_disallowed_items(result)` after every `_eval(node)` call to close CVE-2026-32640. The fix is correct but over-broad: it fires on every intermediate AST node (name lookups, attribute accesses, arithmetic sub-expressions, list comprehension elements, …) even though dangerous values can only *enter* the evaluator through the `names` dict.

PR #176 reduced the *per-call cost* of `_check_disallowed_items` (primitive fast-path, `callable` instead of `is_hashable`). This PR addresses the orthogonal problem: the *call frequency*. Instead of calling the check once per AST node, it is called once per name lookup — the single site where values cross the trust boundary from the caller's `names`/`functions` dicts into the evaluator.

## Why this is safe

| Attack vector | Blocked by |
|---|---|
| Bare module in `names` | `_check_disallowed_items` in `_eval_name` (this PR) |
| Module reached via attribute chain | existing `isinstance(item, types.ModuleType)` in `_eval_attribute` |
| `DISALLOW_FUNCTIONS` callable called directly | existing check in `_eval_call` |
| `DISALLOW_PREFIXES` (`__`/`func_`) attribute access | existing prefix loop in `_eval_attribute` |
| Container in `names` holding a module/disallowed callable | `_check_disallowed_items` recursion in `_eval_name` (this PR) |

All existing tests continue to pass unmodified.

## New tests

### `tests/test_check_boundary.py`

Pins the performance property: the number of `_check_disallowed_items` calls equals the number of name lookups, not the total number of AST nodes evaluated.

### `tests/test_module_wrapper.py`

- `TestModuleNeedsWrapping` — regression tests asserting that bare modules (including those nested inside lists or dicts) still raise `FeatureNotAvailable`.
- `TestModuleWrapperAccess` — extended with container-blocking cases and a `EvalWithCompoundTypes` chained-access case to confirm `ModuleWrapper` remains the correct opt-in path.

## Performance impact

A downstream user ([Meltano Singer SDK](https://github.com/meltano/sdk)) first reported the regression in [meltano/sdk#3565](https://github.com/meltano/sdk/pull/3565#issuecomment-4057644699), which led to PR #176. Even after #176 landed, the SDK benchmark still showed a regression because the fundamental issue — O(AST nodes) calls rather than O(name lookups) — remained. The SDK counted **24 `_check_disallowed_items` calls per record transform** (3 expressions × ~8 AST nodes each); this PR reduces that to the number of distinct name occurrences in those expressions.

Confirmed by [meltano/sdk#3596](https://github.com/meltano/sdk/pull/3596): with this change applied, the SDK shows no performance regression whatsoever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</p>
</details> 
