### PR TITLE
fix: Avoid infinite recursion when evaluating relf-referential containers

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -620,7 +620,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
     def __del__(self):
         self.nodes = None
 
-    def _check_disallowed_items(self, item):
+    def _check_disallowed_items(self, item, _visited: Union[Set[int], None] = None):
         """Check if item contains disallowed functions or modules.
         Recursively checks containers (list, dict, tuple).
         Raises FeatureNotAvailable if forbidden content found.
@@ -637,12 +637,19 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         if isinstance(item, types.ModuleType):
             raise FeatureNotAvailable("Sorry, modules are not allowed")
 
-        if isinstance(item, (list, tuple)):
-            for element in item:
-                self._check_disallowed_items(element)
-        elif isinstance(item, dict):
-            for value in item.values():
-                self._check_disallowed_items(value)
+        if isinstance(item, (list, tuple, dict)):
+            if _visited is None:
+                _visited = set()
+            item_id = id(item)
+            if item_id in _visited:
+                return
+            _visited.add(item_id)
+            if isinstance(item, (list, tuple)):
+                for element in item:
+                    self._check_disallowed_items(element, _visited)
+            else:
+                for value in item.values():
+                    self._check_disallowed_items(value, _visited)
         elif callable(item) and item in DISALLOW_FUNCTIONS:
             raise FeatureNotAvailable("This function is forbidden")
 

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -237,6 +237,7 @@ class TestNames(DRYTest):
         d["self"] = d
         self.s.names = d
         self.t("x", 1)
+        self.t("self['self']['x']", 1)
 
     def test_cyclical_list_in_names(self):
         """A list that contains itself should not cause RecursionError (issue #180)"""
@@ -244,3 +245,4 @@ class TestNames(DRYTest):
         lst.append(lst)
         self.s.names = {"lst": lst}
         self.t("lst[0]", 1)
+        self.t("lst[-1][-1][0]", 1)

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -229,3 +229,18 @@ class TestNames(DRYTest):
 
         with self.assertRaises(KeyError):
             self.t("c", None)
+
+    def test_cyclical_names_dict(self):
+        """Cyclical containers in names should not cause RecursionError (issue #180)"""
+        # A dict that contains a reference to itself
+        d: dict = {"x": 1}
+        d["self"] = d
+        self.s.names = d
+        self.t("x", 1)
+
+    def test_cyclical_list_in_names(self):
+        """A list that contains itself should not cause RecursionError (issue #180)"""
+        lst: list = [1, 2, 3]
+        lst.append(lst)
+        self.s.names = {"lst": lst}
+        self.t("lst[0]", 1)


### PR DESCRIPTION
# Description
_What is this PR doing?_

Use memoization to register already-visited containers and avoid infinite recursion.

Closes #180

# Pre-approval checklist (for submitter)
_Please complete these steps_
- [x] Passes tests
- [x] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)
