### PR TITLE
docs: fix module docstring article

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -2,7 +2,7 @@
 SimpleEval - (C) 2013-2026 Daniel Fairhead
 -------------------------------------
 
-An short, easy to use, safe and reasonably extensible expression evaluator.
+A short, easy to use, safe and reasonably extensible expression evaluator.
 Designed for things like in a website where you want to allow the user to
 generate a string, or a number from some other input, without allowing full
 eval() or other unsafe or needlessly complex linguistics.


### PR DESCRIPTION
# Description
Fix the module docstring article in `simpleeval.py` so it reads "A short..." instead of "An short...".

# Pre-approval checklist (for submitter)
- [x] Passes tests
- [ ] New tests for additional features or changed functionality
- [x] My name and contribution added to contributors list (or if I'd rather opt out, I've said so in the PR)

I'd prefer to opt out of adding my name to the contributors list for this docs-only typo fix.

Tests run:
- `pytest -q` (159 passed)
- `git diff --check`