### PR TITLE
fix: correct typo in module docstring

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -2,7 +2,7 @@
 SimpleEval - (C) 2013-2026 Daniel Fairhead
 -------------------------------------
 
-An short, easy to use, safe and reasonably extensible expression evaluator.
+A short, easy to use, safe and reasonably extensible expression evaluator.
 Designed for things like in a website where you want to allow the user to
 generate a string, or a number from some other input, without allowing full
 eval() or other unsafe or needlessly complex linguistics.


### PR DESCRIPTION
## Summary\n\nFixes #183 - corrects the typo 'An short' to 'A short' in the module docstring.\n\n## Change\n\nLine 5 of simpleeval.py: 'An short, easy to use...' → 'A short, easy to use...'