### PR TITLE
Raise FeatureNotAvailable for unsupported comprehension targets

### DIFF
--- a/simpleeval.py
+++ b/simpleeval.py
@@ -1000,9 +1000,14 @@ class EvalWithCompoundTypes(SimpleEval):
             """
             if isinstance(target, ast.Name):
                 extra_names[target.id] = value
-            else:
+            elif isinstance(target, (ast.Tuple, ast.List)):
                 for t, v in zip(target.elts, value):
                     recurse_targets(t, v)
+            else:
+                raise FeatureNotAvailable(
+                    "Only names and tuple/list unpacking are supported as "
+                    "comprehension assignment targets"
+                )
 
         def do_generator(gi=0):
             g = node.generators[gi]

--- a/tests/test_comprehensions.py
+++ b/tests/test_comprehensions.py
@@ -35,6 +35,23 @@ class TestComprehensions(DRYTest):
     def test_nested_unpack(self):
         self.t("[a+b+c for a, (b, c) in ((1,(1,1)),(3,(2,2)))]", [3, 7])
 
+    def test_subscript_target_fails_cleanly(self):
+        # https://github.com/danthedeckie/simpleeval/issues/76 - a subscript
+        # assignment target used to raise a raw AttributeError instead of a
+        # SimpleEval exception.
+        with self.assertRaises(FeatureNotAvailable):
+            self.t("[x for x in ([None],) for x[0] in (15,)]", None)
+
+    def test_attribute_target_fails_cleanly(self):
+        with self.assertRaises(FeatureNotAvailable):
+            self.t("[x for x in (1,) for x.imag in (15,)]", None)
+
+    def test_self_referential_target_blocked(self):
+        # The subscript-target path could otherwise build a self-referential
+        # list (a potential DoS vector); it must be rejected, not constructed.
+        with self.assertRaises(FeatureNotAvailable):
+            self.t("[x for x in ([None],) for x[0] in (x,)]", None)
+
     def test_dictcomp_basic(self):
         self.t("{a:a + 1 for a in [1,2,3]}", {1: 2, 2: 3, 3: 4})
 

--- a/tests/test_comprehensions.py
+++ b/tests/test_comprehensions.py
@@ -46,9 +46,9 @@ class TestComprehensions(DRYTest):
         with self.assertRaises(FeatureNotAvailable):
             self.t("[x for x in (1,) for x.imag in (15,)]", None)
 
-    def test_self_referential_target_blocked(self):
-        # The subscript-target path could otherwise build a self-referential
-        # list (a potential DoS vector); it must be rejected, not constructed.
+    def test_self_referential_target_fails_cleanly(self):
+        # The variant from the issue thread; same subscript-target path, so it
+        # raises FeatureNotAvailable rather than a raw AttributeError.
         with self.assertRaises(FeatureNotAvailable):
             self.t("[x for x in ([None],) for x[0] in (x,)]", None)
 


### PR DESCRIPTION
## Summary

Fixes #76. A list/dict comprehension whose `for` clause uses a non-name assignment target — a subscript like `x[0]` or an attribute like `x.attr` — crashes with a raw, non-SimpleEval exception:

```python
>>> EvalWithCompoundTypes().eval("[x for x in ([None],) for x[0] in (15,)]")
AttributeError: 'Subscript' object has no attribute 'elts'
```

`recurse_targets` only special-cased `ast.Name` and assumed every other target was a tuple/list with an `.elts` attribute.

## Fix

Handle `ast.Name` and `ast.Tuple`/`ast.List` explicitly, and raise the library's own `FeatureNotAvailable` for any other target type, so the sandbox raises a `SimpleEval` exception instead of leaking an `AttributeError`.

This does **not** implement subscript assignment (`container[key] = value`). That would be the first form of mutation through an assignment target in the evaluator, which is a feature decision about what the sandbox should allow — separate from fixing the crash.

## Verification

- Reproduced on `main` (`afd1ffc`): subscript target raises a raw `AttributeError`; after the fix it raises `FeatureNotAvailable`, as does an attribute target.
- All existing name / tuple / list / nested-unpack / dict-comprehension paths are unchanged.
- Added 3 regression tests; each fails before the change (raw `AttributeError`) and passes after.
- Full test suite: **162 passed** (159 + 3). `ruff==0.6.9` and `mypy==1.11.2` clean.

---

This pull request was prepared with the assistance of AI, under my direction and review.
